### PR TITLE
fix: 修复 IIFE 产物问题并开启压缩

### DIFF
--- a/src/iife.ts
+++ b/src/iife.ts
@@ -1,0 +1,1 @@
+export { default } from './index.js'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,23 +1,29 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: { index: 'src/index.ts' },
-  format: ['esm', 'cjs', 'iife'],
-  globalName: 'uaBrowser',
-  dts: true,
-  clean: true,
-  minify: false,
-  sourcemap: true,
-  treeshake: true,
-  target: 'es2018',
-  outExtension({ format }) {
-    if (format === 'esm') return { js: '.mjs' }
-    if (format === 'cjs') return { js: '.cjs' }
-    return { js: '.min.js' }
+export default defineConfig([
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    treeshake: true,
+    target: 'es2018',
+    sourcemap: true,
+    outExtension({ format }) {
+      if (format === 'esm') return { js: '.mjs' }
+      return { js: '.cjs' }
+    },
   },
-  rollupOptions: {
-    output: {
-      exports: 'named'
-    }
-  }
-})
+  {
+    entry: { index: 'src/iife.ts' },
+    format: ['iife'],
+    globalName: 'uaBrowser',
+    clean: false,
+    treeshake: true,
+    target: 'es2018',
+    sourcemap: true,
+    outExtension() {
+      return { js: '.min.js' }
+    },
+  },
+])

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig([
     format: ['iife'],
     globalName: 'uaBrowser',
     clean: false,
+    minify: true,
     treeshake: true,
     target: 'es2018',
     sourcemap: true,


### PR DESCRIPTION
## 变更内容

- 修复 IIFE 产物中 `window.uaBrowser` 被包裹为对象的问题，现在可直接调用 `uaBrowser()`
- IIFE 产物开启压缩，体积从 18KB 减少至 11KB