### PR TITLE
fix: 修正 GitHub Pages 资源 404 问题

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,9 +4,10 @@ export default defineConfig({
   title: 'uaBrowser',
   description: '通过 User Agent 检测浏览器、系统及设备类型，零依赖',
   lang: 'zh-CN',
+  base: '/ua-browser/',
 
   head: [
-    ['link', { rel: 'icon', href: '/favicon.ico' }],
+    ['link', { rel: 'icon', href: '/ua-browser/favicon.ico' }],
   ],
 
   themeConfig: {


### PR DESCRIPTION
VitePress 部署到 GitHub Pages 子路径时需设置 `base: '/ua-browser/'`，否则 JS/CSS 等静态资源路径错误导致 404。