### PR TITLE
fix: 更新 import 断言语法为 import 属性

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import pkg from '../package.json' assert { type: 'json' }
+import pkg from '../package.json' with { type: 'json' }
 const { version: VERSION } = pkg
 import { parseUA } from './parse.js'
 import { getNavContext, getLanguage } from './utils/navigator.js'


### PR DESCRIPTION
将 `assert { type: 'json' }` 更新为 `with { type: 'json' }`，符合 TypeScript 5.3+ 的 import 属性规范。