### PR TITLE
docs: 优化 Playground 布局并完善文档导航

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,32 +16,27 @@ export default defineConfig({
 
     nav: [
       { text: '指南', link: '/guide/getting-started' },
-      { text: 'API', link: '/api/' },
       { text: 'Playground', link: '/playground' },
       { text: '更新日志', link: '/changelog' },
     ],
 
-    sidebar: {
-      '/guide/': [
-        {
-          text: '指南',
-          items: [
-            { text: '快速开始', link: '/guide/getting-started' },
-            { text: '使用示例', link: '/guide/examples' },
-            { text: '内置支持列表', link: '/guide/support-list' },
-          ],
-        },
-      ],
-      '/api/': [
-        {
-          text: 'API 参考',
-          items: [
-            { text: '总览', link: '/api/' },
-            { text: '类型定义', link: '/api/types' },
-          ],
-        },
-      ],
-    },
+    sidebar: [
+      {
+        text: '指南',
+        items: [
+          { text: '快速开始', link: '/guide/getting-started' },
+          { text: '使用示例', link: '/guide/examples' },
+          { text: '内置支持列表', link: '/guide/support-list' },
+        ],
+      },
+      {
+        text: 'API 参考',
+        items: [
+          { text: '总览', link: '/api/' },
+          { text: '类型定义', link: '/api/types' },
+        ],
+      },
+    ],
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/yangtianxia/ua-browser' },
@@ -52,6 +47,8 @@ export default defineConfig({
       message: 'Released under the MIT License.',
       copyright: 'Copyright © 2024 yangtianxia',
     },
+
+    outline: false,
 
     search: {
       provider: 'local',

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -62,19 +62,19 @@ const PRESET_UAS = [
 
 const uaInput = ref('')
 const result = ref<ParseResult | null>(null)
-const parseUA = ref<((ua: string) => ParseResult) | null>(null)
+const uaBrowser = ref<((ua: string) => ParseResult) | null>(null)
 const loaded = ref(false)
 
 onMounted(async () => {
   const mod = await import('ua-browser')
-  parseUA.value = mod.parseUA
+  uaBrowser.value = mod.default
   loaded.value = true
   useCurrentUA()
 })
 
 function parse() {
-  if (!parseUA.value || !uaInput.value.trim()) return
-  result.value = parseUA.value(uaInput.value.trim())
+  if (!uaBrowser.value || !uaInput.value.trim()) return
+  result.value = uaBrowser.value(uaInput.value.trim())
 }
 
 function usePreset(ua: string) {
@@ -140,7 +140,7 @@ const fields = computed(() => {
           v-model="uaInput"
           class="ua-textarea"
           placeholder="输入 User Agent 字符串..."
-          rows="5"
+          rows="6"
           spellcheck="false"
           @keydown.enter.ctrl="parse"
           @keydown.enter.meta="parse"
@@ -152,7 +152,7 @@ const fields = computed(() => {
     </div>
 
     <div class="playground-right">
-      <div v-if="result" class="playground-result">
+      <template v-if="result">
         <div v-if="tags.length" class="result-tags">
           <span
             v-for="tag in tags"
@@ -174,10 +174,8 @@ const fields = computed(() => {
           <summary>原始 JSON</summary>
           <pre>{{ JSON.stringify(result, null, 2) }}</pre>
         </details>
-      </div>
-      <div v-else class="playground-empty">
-        <span>解析结果将显示在此处</span>
-      </div>
+      </template>
+      <div v-else class="result-empty">解析结果将显示在此处</div>
     </div>
   </div>
 </template>
@@ -186,17 +184,19 @@ const fields = computed(() => {
 .playground {
   display: flex;
   gap: 24px;
+  align-items: flex-start;
   border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
   padding: 24px;
-  margin: 24px 0;
   background: var(--vp-c-bg-soft);
-  align-items: flex-start;
 }
 
 .playground-left {
-  flex: 0 0 42%;
+  flex: 0 0 38%;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .playground-right {
@@ -209,7 +209,6 @@ const fields = computed(() => {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-  margin-bottom: 16px;
 }
 
 .presets-label {
@@ -247,6 +246,7 @@ const fields = computed(() => {
 
 .ua-textarea {
   width: 100%;
+  box-sizing: border-box;
   padding: 10px 12px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
@@ -257,7 +257,6 @@ const fields = computed(() => {
   line-height: 1.6;
   resize: vertical;
   transition: border-color 0.2s;
-  box-sizing: border-box;
 }
 
 .ua-textarea:focus {
@@ -287,12 +286,11 @@ const fields = computed(() => {
   opacity: 0.85;
 }
 
-.playground-empty {
+.result-empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  min-height: 120px;
+  min-height: 160px;
   color: var(--vp-c-text-3);
   font-size: 13px;
   border: 1px dashed var(--vp-c-divider);
@@ -301,8 +299,9 @@ const fields = computed(() => {
 
 .result-tags {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .result-tag {
@@ -324,7 +323,7 @@ const fields = computed(() => {
 
 .result-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 1px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
@@ -356,7 +355,7 @@ const fields = computed(() => {
 }
 
 .result-raw {
-  margin-top: 16px;
+  margin-top: 14px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
   overflow: hidden;

--- a/docs/.vitepress/theme/components/SidebarOutline.vue
+++ b/docs/.vitepress/theme/components/SidebarOutline.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useData, useRoute } from 'vitepress'
+
+const { page } = useData()
+const route = useRoute()
+const activeSlug = ref('')
+
+let observer: IntersectionObserver | null = null
+
+function setup() {
+  observer?.disconnect()
+  activeSlug.value = ''
+
+  nextTick(() => {
+    const headings = Array.from(
+      document.querySelectorAll<HTMLElement>('.vp-doc h2[id], .vp-doc h3[id]')
+    )
+    if (!headings.length) return
+
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            activeSlug.value = (entry.target as HTMLElement).id
+            break
+          }
+        }
+      },
+      { rootMargin: '-64px 0px -60% 0px', threshold: 0 }
+    )
+
+    headings.forEach((el) => observer!.observe(el))
+  })
+}
+
+onMounted(setup)
+onUnmounted(() => observer?.disconnect())
+watch(() => route.path, () => setTimeout(setup, 200))
+</script>
+
+<template>
+  <div v-if="page.headers?.length" class="sidebar-outline">
+    <div class="outline-title">本页目录</div>
+    <nav class="outline-nav">
+      <a
+        v-for="h in page.headers"
+        :key="h.slug"
+        :href="'#' + h.slug"
+        :class="['outline-link', `level-${h.level}`, { active: activeSlug === h.slug }]"
+      >{{ h.title }}</a>
+    </nav>
+  </div>
+</template>
+
+<style scoped>
+.sidebar-outline {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.outline-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 12px;
+  margin-bottom: 8px;
+}
+
+.outline-nav {
+  display: flex;
+  flex-direction: column;
+}
+
+.outline-link {
+  display: block;
+  padding: 4px 12px;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  border-radius: 6px;
+  transition: color 0.2s, background 0.2s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+}
+
+.outline-link.level-3 {
+  padding-left: 24px;
+  font-size: 12px;
+}
+
+.outline-link:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-default-soft);
+}
+
+.outline-link.active {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  font-weight: 500;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,17 @@
+import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import Playground from './components/Playground.vue'
+import SidebarOutline from './components/SidebarOutline.vue'
+import './style.css'
 import type { Theme } from 'vitepress'
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'sidebar-nav-after': () => h(SidebarOutline),
+    })
+  },
   enhanceApp({ app }) {
     app.component('Playground', Playground)
   },

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,21 @@
+.pg-wrap {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 48px 32px 64px;
+  box-sizing: border-box;
+}
+
+.pg-header {
+  margin-bottom: 8px;
+}
+
+.pg-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.pg-header p {
+  color: var(--vp-c-text-2);
+  font-size: 15px;
+}

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -1,9 +1,16 @@
 ---
 title: Playground
+layout: page
 ---
+
+<div class="pg-wrap">
+<div class="pg-header">
 
 # Playground
 
 输入任意 User Agent 字符串，实时查看解析结果。支持预设常用 UA，或点击「当前浏览器」自动读取。
 
+</div>
+
 <Playground />
+</div>


### PR DESCRIPTION
## 变更内容

- Playground 改为左右布局，使用默认导出 `uaBrowser` 修正 language/platform 返回 unknown 的问题
- Playground 页面改用 `layout: page` 全宽展示
- 左侧边栏新增页内目录，滚动自动高亮当前标题
- 统一侧边栏，指南与 API 参考合并为单一列表
- 禁用右侧 outline，避免重复