### PR TITLE
docs: 完善 Playground 交互与文档导航

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', href: '/ua-browser/favicon.ico' }],
+    ['script', {}, `var _hmt = _hmt || [];(function() {var hm = document.createElement("script");hm.src = "https://hm.baidu.com/hm.js?039f7362d3cebddced40c9a853536a89";var s = document.getElementsByTagName("script")[0];s.parentNode.insertBefore(hm, s);})();`],
   ],
 
   themeConfig: {

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -62,36 +62,47 @@ const PRESET_UAS = [
 
 const uaInput = ref('')
 const result = ref<ParseResult | null>(null)
-const uaBrowser = ref<((ua: string) => ParseResult) | null>(null)
+const selectedKey = ref<string | null>(null)
 const loaded = ref(false)
+
+let _uaBrowser: ((ua?: string) => ParseResult) | null = null
+let _parseUA: ((ua: string) => ParseResult) | null = null
 
 onMounted(async () => {
   const mod = await import('ua-browser')
-  uaBrowser.value = mod.default
+  _uaBrowser = mod.default
+  _parseUA = mod.parseUA
   loaded.value = true
   useCurrentUA()
 })
 
 function parse() {
-  if (!uaBrowser.value || !uaInput.value.trim()) return
-  result.value = uaBrowser.value(uaInput.value.trim())
+  if (!_parseUA || !uaInput.value.trim()) return
+  // 手动输入时清除预设选中
+  selectedKey.value = null
+  result.value = _parseUA(uaInput.value.trim())
 }
 
 function usePreset(ua: string) {
+  if (!_parseUA) return
   uaInput.value = ua
-  parse()
+  selectedKey.value = ua
+  // 预设 UA 不注入 nav，language/platform 返回 unknown
+  result.value = _parseUA(ua)
 }
 
 function useCurrentUA() {
-  if (typeof navigator === 'undefined') return
+  if (!_uaBrowser || typeof navigator === 'undefined') return
   uaInput.value = navigator.userAgent
-  parse()
+  selectedKey.value = 'current'
+  // 当前浏览器使用默认导出，注入真实 nav 上下文
+  result.value = _uaBrowser()
 }
 
 const tags = computed(() => {
   if (!result.value) return []
   const r = result.value
-  const list = []
+  const list: { label: string; value: string; type: string }[] = []
   if (r.isBot) list.push({ label: 'Bot', value: r.botName, type: 'danger' })
   if (r.isHeadless) list.push({ label: 'Headless', value: '是', type: 'warning' })
   if (r.isWebview) list.push({ label: 'Webview', value: '是', type: 'warning' })
@@ -125,12 +136,15 @@ const fields = computed(() => {
         <button
           v-for="item in PRESET_UAS"
           :key="item.label"
-          class="preset-btn"
+          :class="['preset-btn', { 'preset-btn--active': selectedKey === item.ua }]"
           @click="usePreset(item.ua)"
         >
           {{ item.label }}
         </button>
-        <button class="preset-btn preset-btn--current" @click="useCurrentUA">
+        <button
+          :class="['preset-btn', 'preset-btn--current', { 'preset-btn--active': selectedKey === 'current' }]"
+          @click="useCurrentUA"
+        >
           当前浏览器
         </button>
       </div>
@@ -233,9 +247,10 @@ const fields = computed(() => {
   color: var(--vp-c-brand-1);
 }
 
-.preset-btn--current {
+.preset-btn--active {
+  background: var(--vp-c-brand-1);
   border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
+  color: #fff;
 }
 
 .playground-input {

--- a/docs/.vitepress/theme/components/SidebarOutline.vue
+++ b/docs/.vitepress/theme/components/SidebarOutline.vue
@@ -1,107 +1,100 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
-import { useData, useRoute } from 'vitepress'
+import { useData, useRoute, onContentUpdated } from 'vitepress'
 
 const { page } = useData()
 const route = useRoute()
+const targetEl = ref<HTMLElement | null>(null)
 const activeSlug = ref('')
-
 let observer: IntersectionObserver | null = null
 
-function setup() {
+function findTarget() {
+  const items = Array.from(
+    document.querySelectorAll<HTMLElement>('.VPSidebarItem.is-active')
+  )
+  // 取最深层的活跃项（叶子节点，不包含其他活跃子项的那个）
+  targetEl.value =
+    items.filter((el) => !el.querySelector('.VPSidebarItem.is-active')).pop() ?? null
+}
+
+function setupObserver() {
   observer?.disconnect()
   activeSlug.value = ''
 
+  const headings = Array.from(
+    document.querySelectorAll<HTMLElement>('.vp-doc h2[id], .vp-doc h3[id]')
+  )
+  if (!headings.length) return
+
+  observer = new IntersectionObserver(
+    (entries) => {
+      const visible = entries.filter((e) => e.isIntersecting)
+      if (visible.length) {
+        activeSlug.value = (visible[0].target as HTMLElement).id
+      }
+    },
+    { rootMargin: '-64px 0px -60% 0px', threshold: 0 }
+  )
+  headings.forEach((el) => observer!.observe(el))
+}
+
+function refresh() {
   nextTick(() => {
-    const headings = Array.from(
-      document.querySelectorAll<HTMLElement>('.vp-doc h2[id], .vp-doc h3[id]')
-    )
-    if (!headings.length) return
-
-    observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            activeSlug.value = (entry.target as HTMLElement).id
-            break
-          }
-        }
-      },
-      { rootMargin: '-64px 0px -60% 0px', threshold: 0 }
-    )
-
-    headings.forEach((el) => observer!.observe(el))
+    findTarget()
+    setupObserver()
   })
 }
 
-onMounted(setup)
+onMounted(refresh)
 onUnmounted(() => observer?.disconnect())
-watch(() => route.path, () => setTimeout(setup, 200))
+onContentUpdated(refresh)
+watch(() => route.path, () => setTimeout(refresh, 150))
 </script>
 
 <template>
-  <div v-if="page.headers?.length" class="sidebar-outline">
-    <div class="outline-title">本页目录</div>
-    <nav class="outline-nav">
+  <Teleport v-if="targetEl && page.headers?.length" :to="targetEl">
+    <nav class="spo-nav">
       <a
         v-for="h in page.headers"
         :key="h.slug"
         :href="'#' + h.slug"
-        :class="['outline-link', `level-${h.level}`, { active: activeSlug === h.slug }]"
+        :class="['spo-link', `level-${h.level}`, { active: activeSlug === h.slug }]"
       >{{ h.title }}</a>
     </nav>
-  </div>
+  </Teleport>
 </template>
 
 <style scoped>
-.sidebar-outline {
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 1px solid var(--vp-c-divider);
-}
-
-.outline-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--vp-c-text-2);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 0 12px;
-  margin-bottom: 8px;
-}
-
-.outline-nav {
+.spo-nav {
   display: flex;
   flex-direction: column;
+  padding: 4px 0 8px;
 }
 
-.outline-link {
+.spo-link {
   display: block;
-  padding: 4px 12px;
-  font-size: 13px;
+  padding: 3px 16px 3px 28px;
+  font-size: 12.5px;
+  line-height: 1.5;
   color: var(--vp-c-text-2);
   text-decoration: none;
   border-radius: 6px;
-  transition: color 0.2s, background 0.2s;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 1.5;
+  transition: color 0.2s, background 0.2s;
 }
 
-.outline-link.level-3 {
-  padding-left: 24px;
-  font-size: 12px;
+.spo-link.level-3 {
+  padding-left: 40px;
 }
 
-.outline-link:hover {
+.spo-link:hover {
   color: var(--vp-c-text-1);
-  background: var(--vp-c-default-soft);
 }
 
-.outline-link.active {
+.spo-link.active {
   color: var(--vp-c-brand-1);
-  background: var(--vp-c-brand-soft);
   font-weight: 500;
 }
 </style>


### PR DESCRIPTION
## 变更内容

- Playground 预设按钮切换后正确高亮选中状态
- 预设 UA 解析不注入 nav 上下文，language/platform 返回 unknown（仅「当前浏览器」返回真实值）
- 左侧边栏页内目录改用 Teleport 注入到当前活跃项下，滚动自动高亮
- 新增百度统计