### PR TITLE
feat: 新增 Changesets 自动发布工作流

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          title: 'chore: 版本发布'
+          commit: 'chore: 版本发布'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "sideEffects": false,
   "scripts": {
+    "release": "pnpm build && changeset publish",
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",


### PR DESCRIPTION
## 变更内容

- 新增 `.github/workflows/release.yml`：每次推送到 main 自动检测 changeset，有变更时创建版本发布 PR，合并后自动发布到 npm
- `.changeset/config.json` 的 `access` 改为 `public`，确保包可公开发布
- `package.json` 新增 `release` 脚本

## 使用前提

在 GitHub 仓库 Settings → Secrets → Actions 添加 `NPM_TOKEN`（npm Automation Token）