### PR TITLE
fix: 修复代码审查发现的边界条件与逻辑问题

### DIFF
--- a/src/detectors/os.ts
+++ b/src/detectors/os.ts
@@ -45,7 +45,8 @@ export function detectOs(ua: string, windowsVersion?: string | null): OsResult {
           osVersion = mapped
         } else if (matchedDef.name === 'Windows') {
           // For unknown Windows NT versions, fall back to the integer part
-          osVersion = parseInt(normalised, 10).toString()
+          const n = parseInt(normalised, 10)
+          osVersion = isNaN(n) ? 'unknown' : n.toString()
         }
       } else {
         osVersion = normalised

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -42,7 +42,8 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
   // Only runs when a nav context is provided (browser environment).
   if (nav) {
     const chromeGlobal = typeof chrome !== 'undefined' ? chrome : undefined
-    const chromeMajor = parseInt((/Chrome\/([\d]+)/.exec(ua) ?? [])[1] ?? '0', 10)
+    const chromeMatch = /Chrome\/([\d]+)/.exec(ua)
+    const chromeMajor = chromeMatch ? parseInt(chromeMatch[1], 10) : 0
 
     if (chromeGlobal) {
       if (chromeGlobal.adblock2345 || chromeGlobal.common2345) {
@@ -67,7 +68,9 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
         }
 
         if (is360) {
-          if (getMimeType(nav, 'application/gameplugin') || !nav.connection?.saveData) {
+          // 360EE only when saveData is explicitly enabled; default to 360SE
+          const saveDataEnabled = nav.connection?.saveData === true
+          if (getMimeType(nav, 'application/gameplugin') || !saveDataEnabled) {
             browser = '360SE'
           } else {
             browser = '360EE'
@@ -81,9 +84,8 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
   // Baidu UA can include Opera token — Opera takes priority
   if (browser === 'Baidu' && /(Opera|OPR|OPT)/.test(ua)) {
     browser = 'Opera'
-    version = ((/OPR\/([\d.]+)/.exec(ua) ?? [])[1]) ??
-              ((/OPT\/([\d.]+)/.exec(ua) ?? [])[1]) ??
-              ((/Opera\/([\d.]+)/.exec(ua) ?? [])[1]) ?? 'unknown'
+    const opVer = /OPR\/([\d.]+)/.exec(ua) ?? /OPT\/([\d.]+)/.exec(ua) ?? /Opera\/([\d.]+)/.exec(ua)
+    version = opVer?.[1] ?? 'unknown'
   }
 
   // Generic "SomethingBrowser/x.y" catch-all: Chrome-based third-party browsers

--- a/src/utils/windows-version.ts
+++ b/src/utils/windows-version.ts
@@ -15,7 +15,7 @@ export async function getWindowsVersion(nav: NavContext): Promise<string | null>
   }
   try {
     const data = await nav.userAgentData.getHighEntropyValues(['platformVersion'])
-    const major = parseInt(data['platformVersion']?.split('.')[0] ?? '0', 10)
+    const major = parseInt(data['platformVersion']?.split('.')[0] || '0', 10)
     return major >= 13 ? '11' : '10'
   } catch {
     return null


### PR DESCRIPTION
## 变更内容

- `parse.ts` — 清理 `chromeMajor` 提取逻辑，避免隐式 `NaN` 依赖
- `parse.ts` — 简化 Baidu/Opera 版本链式提取，失败时明确返回 `unknown`
- `parse.ts` — 修正 360SE/EE 判断逻辑，`saveData` 未定义时明确默认为 360SE
- `os.ts` — 修复未知 Windows NT 版本号 `parseInt` 可能产生 `"NaN"` 字符串的问题
- `windows-version.ts` — 修复 `platformVersion` 为空字符串时 `??` 不触发导致 `parseInt('')` 得 `NaN` 的边界问题