### PR TITLE
feat: 新增 AI 爬虫检测支持

### DIFF
--- a/src/constants/bots.ts
+++ b/src/constants/bots.ts
@@ -16,6 +16,11 @@ export type BotName =
   | 'AhrefsBot'
   | 'MJ12bot'
   | 'PetalBot'
+  | 'GPTBot'
+  | 'ClaudeBot'
+  | 'PerplexityBot'
+  | 'CCBot'
+  | 'AdsBot'
   | 'GenericBot'
   | 'unknown'
 
@@ -42,9 +47,15 @@ export const BOT_DEFS: readonly BotDef[] = [
   { name: 'Twitterbot',  detect: /Twitterbot/ },
   { name: 'LinkedInBot', detect: /LinkedInBot/ },
   // SEO tools
-  { name: 'SemrushBot',  detect: /SemrushBot/ },
-  { name: 'AhrefsBot',   detect: /AhrefsBot/ },
-  { name: 'MJ12bot',     detect: /MJ12bot/ },
+  { name: 'SemrushBot',    detect: /SemrushBot/ },
+  { name: 'AhrefsBot',     detect: /AhrefsBot/ },
+  { name: 'MJ12bot',       detect: /MJ12bot/ },
+  // AI / LLM crawlers
+  { name: 'GPTBot',        detect: /GPTBot/ },
+  { name: 'ClaudeBot',     detect: /ClaudeBot/ },
+  { name: 'PerplexityBot', detect: /PerplexityBot/ },
+  { name: 'CCBot',         detect: /CCBot/ },
+  { name: 'AdsBot',        detect: /AdsBot-Google/ },
   // Generic catch-all (must be last)
-  { name: 'GenericBot',  detect: /(bot|crawler|spider|crawling|scraper)/i }
+  { name: 'GenericBot',    detect: /(bot|crawler|spider|crawling|scraper)/i }
 ] as const

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,11 @@ export type BotName =
   | 'AhrefsBot'
   | 'MJ12bot'
   | 'PetalBot'
+  | 'GPTBot'
+  | 'ClaudeBot'
+  | 'PerplexityBot'
+  | 'CCBot'
+  | 'AdsBot'
   | 'GenericBot'
   | 'unknown'
 

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -60,6 +60,41 @@ describe('detectBot', () => {
       expect(r.botName).toBe('AhrefsBot')
     })
 
+    it('detects GPTBot', () => {
+      const ua = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.1; +https://openai.com/gptbot'
+      const r = detectBot(ua)
+      expect(r.isBot).toBe(true)
+      expect(r.botName).toBe('GPTBot')
+    })
+
+    it('detects ClaudeBot', () => {
+      const ua = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/0.1; +claudebot@anthropic.com'
+      const r = detectBot(ua)
+      expect(r.isBot).toBe(true)
+      expect(r.botName).toBe('ClaudeBot')
+    })
+
+    it('detects PerplexityBot', () => {
+      const ua = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; PerplexityBot/1.0; +https://docs.perplexity.ai/docs/perplexitybot'
+      const r = detectBot(ua)
+      expect(r.isBot).toBe(true)
+      expect(r.botName).toBe('PerplexityBot')
+    })
+
+    it('detects CCBot (Common Crawl)', () => {
+      const ua = 'CCBot/2.0 (https://commoncrawl.org/faq/)'
+      const r = detectBot(ua)
+      expect(r.isBot).toBe(true)
+      expect(r.botName).toBe('CCBot')
+    })
+
+    it('detects AdsBot-Google', () => {
+      const ua = 'AdsBot-Google (+http://www.google.com/adsbot.html)'
+      const r = detectBot(ua)
+      expect(r.isBot).toBe(true)
+      expect(r.botName).toBe('AdsBot')
+    })
+
     it('detects generic bot by keyword', () => {
       const ua = 'MyCustomCrawler/1.0 (a custom web crawler)'
       const r = detectBot(ua)


### PR DESCRIPTION
## 概述

补充 5 个主流 AI / LLM 爬虫的识别支持：

- **GPTBot** — OpenAI 网页抓取机器人
- **ClaudeBot** — Anthropic 网页抓取机器人
- **PerplexityBot** — Perplexity AI 抓取机器人
- **CCBot** — Common Crawl（大模型训练数据来源）
- **AdsBot** — Google Ads 抓取机器人（AdsBot-Google）

## 变更

- `src/constants/bots.ts` — `BotName` 新增 5 个值，`BOT_DEFS` 新增对应检测规则
- `src/types.ts` — `BotName` 联合类型同步更新
- `test/bot.test.ts` — 新增 5 个测试用例，全部通过（共 144 个测试）