### PR TITLE
feat: 新增 Tizen、KaiOS 操作系统检测

### DIFF
--- a/src/constants/os.ts
+++ b/src/constants/os.ts
@@ -20,11 +20,13 @@ export const OS_DEFS: readonly OsDef[] = [
   { name: 'Ubuntu',         detect: /Ubuntu/,                         versionPattern: null },
   { name: 'Chrome OS',      detect: /CrOS/,                           versionPattern: null },
   { name: 'Linux',          detect: /(Linux|X11)/,                    versionPattern: null },
+  { name: 'Tizen',          detect: /Tizen/,                          versionPattern: /Tizen ([\d.]+)/ },
   { name: 'iOS',            detect: /like Mac OS X/,                  versionPattern: /OS ([\d_]+) like/ },
   { name: 'MacOS',          detect: /Macintosh/,                      versionPattern: /Mac OS X -?([\d_.]+)/ },
   { name: 'HarmonyOS',      detect: /HarmonyOS/,                      versionPattern: /Android ([\d.]+)[;)]/,
     versionLookup: { '10': '2' } },
   { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
+  { name: 'KaiOS',          detect: /KAIOS/,                          versionPattern: /KAIOS\/([\d.]+)/ },
   { name: 'Windows',        detect: /Windows/,                        versionPattern: /Windows NT ([\d.]+)/,
     versionLookup: {
       '10': '10', '6.4': '10', '6.3': '8.1', '6.2': '8',

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,8 @@ export type OsName =
   | 'iOS'
   | 'Chrome OS'
   | 'WebOS'
+  | 'Tizen'
+  | 'KaiOS'
   | 'unknown'
 
 export type DeviceName = 'Mobile' | 'Tablet' | 'PC'

--- a/test/os.test.ts
+++ b/test/os.test.ts
@@ -52,6 +52,20 @@ describe('detectOs', () => {
     expect(r.osVersion).toBe('11')
   })
 
+  it('Tizen Smart TV', () => {
+    const ua = 'Mozilla/5.0 (SMART-TV; Linux; Tizen 6.0) AppleWebKit/538.1 (KHTML, like Gecko) Version/6.0 TV Safari/538.1'
+    const r = detectOs(ua)
+    expect(r.os).toBe('Tizen')
+    expect(r.osVersion).toBe('6.0')
+  })
+
+  it('KaiOS feature phone', () => {
+    const ua = 'Mozilla/5.0 (Mobile; LYF/F90M/LYF-F90M; Android 4.4.2; rv:65.0) Gecko/65.0 Firefox/65.0 KAIOS/2.5.2'
+    const r = detectOs(ua)
+    expect(r.os).toBe('KaiOS')
+    expect(r.osVersion).toBe('2.5.2')
+  })
+
   it('returns unknown for empty UA', () => {
     const r = detectOs('')
     expect(r.os).toBe('unknown')


### PR DESCRIPTION
## 概述

补充 2 个有实际 Web 流量的操作系统检测：

- **Tizen** — 三星智能电视 / 可穿戴设备系统，检测 `Tizen` 标识，提取版本号
- **KaiOS** — 发展中国家功能机系统（印度、非洲市场），检测 `KAIOS/` 标识，提取版本号

两者在数组中分别放置于 `Linux`、`Android` 之后，确保优先级正确覆盖。

## 变更

- `src/constants/os.ts` — 新增 2 条 `OsDef`
- `src/types.ts` — `OsName` 联合类型新增 `'Tizen'`、`'KaiOS'`
- `test/os.test.ts` — 新增 2 个测试用例，共 146 个测试全部通过