### PR TITLE
feat: 完善设备检测，新增 TV 类型与 Android 平板规则

### DIFF
--- a/src/constants/devices.ts
+++ b/src/constants/devices.ts
@@ -4,6 +4,6 @@ export interface DeviceDef {
 }
 
 export const DEVICE_DEFS: readonly DeviceDef[] = [
-  { name: 'Mobile', detect: /(Mobi|iPh|480)/ },
-  { name: 'Tablet', detect: /(Tablet|Pad|Nexus 7)/ }
+  { name: 'Mobile', detect: /(Mobi|iPh)/ },
+  { name: 'Tablet', detect: /(Tablet|Pad)/ }
 ] as const

--- a/src/detectors/device.ts
+++ b/src/detectors/device.ts
@@ -10,13 +10,23 @@ import type { NavContext } from '../utils/navigator.js'
  *              (where the UA reports "Macintosh" but maxTouchPoints > 1)
  */
 export function detectDevice(ua: string, nav?: Pick<NavContext, 'platform' | 'maxTouchPoints'>): DeviceName {
-  // Modern iPad reports platform='MacIntel' and UA contains 'Macintosh'
+  // Smart TV — must come first; some TV UAs also contain Android/Linux tokens
+  if (/(SMART-TV|HbbTV|SmartTV|TV Safari|Android TV|GoogleTV)/.test(ua)) {
+    return 'TV'
+  }
+
+  // Modern iPad: platform='MacIntel' with touch points (iPadOS 13+)
   if (nav?.platform === 'MacIntel' && nav.maxTouchPoints > 1) {
     return 'Tablet'
   }
 
-  // iPad in UA string while device would otherwise be Mobile (older iPads)
+  // iPad in UA string (older iPads)
   if (/iPad/.test(ua)) {
+    return 'Tablet'
+  }
+
+  // Android tablet: has Android but no Mobile marker
+  if (/Android/.test(ua) && !/Mobile/.test(ua)) {
     return 'Tablet'
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export type OsName =
   | 'KaiOS'
   | 'unknown'
 
-export type DeviceName = 'Mobile' | 'Tablet' | 'PC'
+export type DeviceName = 'Mobile' | 'Tablet' | 'PC' | 'TV'
 
 export type ArchName = 'x86' | 'x86_64' | 'arm' | 'arm64' | 'unknown'
 

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -29,6 +29,21 @@ describe('detectDevice', () => {
     expect(detectDevice(UA.safari.ios)).toBe('Mobile')
   })
 
+  it('Android tablet (no Mobile marker) → Tablet', () => {
+    const ua = 'Mozilla/5.0 (Linux; Android 10; SM-T515) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Safari/537.36'
+    expect(detectDevice(ua)).toBe('Tablet')
+  })
+
+  it('Samsung Smart TV → TV', () => {
+    const ua = 'Mozilla/5.0 (SMART-TV; Linux; Tizen 6.0) AppleWebKit/538.1 (KHTML, like Gecko) Version/6.0 TV Safari/538.1'
+    expect(detectDevice(ua)).toBe('TV')
+  })
+
+  it('HbbTV device → TV', () => {
+    const ua = 'Mozilla/5.0 (Linux; HbbTV/1.4.7 (+PVR+DL; Philips; TV; ; ; ;) CE-HTML/1.0 NETTV/4.4.0 SmartTV2018)'
+    expect(detectDevice(ua)).toBe('TV')
+  })
+
   it('empty UA → PC', () => {
     expect(detectDevice('')).toBe('PC')
   })


### PR DESCRIPTION
## 概述

修复设备检测的已知缺陷，并新增 Smart TV 支持：

- **移除 `"480"`** — 基于分辨率的旧式移动判断，已过时且易误判
- **移除 `"Nexus 7"`** — 过于具体的机型硬编码，由下方通用规则覆盖
- **Android 平板规则** — 含 `Android` 但不含 `Mobile` 标识的 UA 识别为平板（解决三星 Galaxy Tab 等误判为 PC 的问题）
- **Smart TV 检测** — 新增 `'TV'` 设备类型，识别 `SMART-TV`、`HbbTV`、`SmartTV`、`Android TV`、`GoogleTV` 等标识

## 变更

- `src/types.ts` — `DeviceName` 新增 `'TV'`
- `src/constants/devices.ts` — 清理过时规则
- `src/detectors/device.ts` — 新增 TV 优先检测、Android 平板规则
- `test/device.test.ts` — 新增 3 个测试用例，共 149 个测试全部通过