### PR TITLE
feat: 无头浏览器检测补充 jsdom、Selenium 识别

### DIFF
--- a/src/detectors/headless.ts
+++ b/src/detectors/headless.ts
@@ -7,9 +7,11 @@
  * | Headless         | Generic headless marker in some frameworks          |
  * | PhantomJS        | PhantomJS (deprecated but still used)               |
  * | Electron         | Electron apps (not strictly headless, but automated)|
- * | Playwright       | Playwright may inject its own token                 |
+ * | Playwright       | Playwright automation framework                     |
+ * | jsdom            | Node.js DOM simulation (vitest, jest-environment)   |
+ * | Selenium         | Some WebDriver/Selenium setups inject this token    |
  */
-const HEADLESS_PATTERN = /(HeadlessChrome|Headless|PhantomJS|Electron\/|Playwright)/
+const HEADLESS_PATTERN = /(HeadlessChrome|Headless|PhantomJS|Electron\/|Playwright|jsdom\/|Selenium)/
 
 /**
  * Detect whether the UA belongs to a headless or automation-driven browser.

--- a/test/headless.test.ts
+++ b/test/headless.test.ts
@@ -23,6 +23,16 @@ describe('detectHeadless', () => {
     expect(detectHeadless(ua)).toBe(true)
   })
 
+  it('jsdom UA → true', () => {
+    const ua = 'Mozilla/5.0 (linux) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3'
+    expect(detectHeadless(ua)).toBe(true)
+  })
+
+  it('Selenium WebDriver UA → true', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Selenium/4.0'
+    expect(detectHeadless(ua)).toBe(true)
+  })
+
   it('normal Chrome → false', () => {
     expect(detectHeadless(UA.chrome.windows)).toBe(false)
   })


### PR DESCRIPTION
## 概述

补充两个常见自动化环境的识别：

- **jsdom** — Node.js DOM 模拟库，广泛用于 Jest / Vitest 测试环境，UA 含 `jsdom/` 标识
- **Selenium** — 部分 WebDriver / Selenium 配置会在 UA 中注入 `Selenium` 标识

> Cypress、WebdriverIO 默认不修改 UA，无法从 UA 层面检测。

## 变更

- `src/detectors/headless.ts` — `HEADLESS_PATTERN` 新增 `jsdom\/` 和 `Selenium` 两个模式
- `test/headless.test.ts` — 新增 2 个测试用例，共 151 个测试全部通过