### PR TITLE
docs: 补写 1.0.0 changelog 并新增 Git 工作流规范

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # ua-browser
 
+## 1.0.0
+
+### Major Changes
+
+**架构重写，全面升级为模块化纯函数设计。**
+
+#### 破坏性变更
+
+- `result.platfrom`（拼写错误）已更正为 `result.platform`
+- 移除 `EnvPart` 类型，统一使用 `EnvOption`
+- 移除单例模式，改为纯函数 `parseUA(ua, options?)`
+
+#### 新增功能
+
+- **`parseUA(ua, options?)`** — 纯函数版本，适用于 SSR / Node.js 环境
+- **`getNavContext()`** — 读取真实 `navigator` 并返回 `NavContext`，Node.js 下安全降级
+- **`getWindowsVersion(nav)`** — 异步精确区分 Windows 10 / 11
+- **`detectBot(ua)`** — 独立爬虫检测器，返回 `{ isBot, botName }`
+- **`detectArch(ua)`** — 独立 CPU 架构检测器
+- **`detectHeadless(ua)`** — 独立无头浏览器检测器
+- **`getLanguage(nav)`** — 从 `NavContext` 提取标准化语言代码
+- **`VERSION`** — 导出当前库版本号
+- 新增命名导出，支持 Tree-shaking
+- 新增 `NavContext` 注入机制，消除全局副作用，所有检测器可在 Node.js 测试
+
+#### 检测能力扩展
+
+- 新增浏览器：Samsung Internet、DuckDuckGo、Puffin
+- 新增操作系统：Tizen、KaiOS
+- 新增设备类型：`TV`（智能电视）
+- 新增 Android 无 `Mobile` 标记时自动识别为平板
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增无头浏览器标记：jsdom、Selenium、Playwright
+
+#### 构建系统
+
+- 从 Rollup + Babel + shelljs 迁移至 **tsup + TypeScript 5**
+- 产物格式：ESM（`.mjs`）、CommonJS（`.cjs`）、IIFE（`.min.js`）、类型声明（`.d.ts` / `.d.cts`）
+- 新增 **Vitest** 测试套件
+
+---
+
 ## 0.1.9
 
 ### Patch Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npx changeset version # bump versions and update CHANGELOG.md
 - **所有功能、修复、文档 PR 的目标分支为 `dev`**，不得直接合并到 `main`
 - **`main` 只接受来自 `dev` 的发布 PR**，或紧急 hotfix
 - 分支命名：`feat/xxx`、`fix/xxx`、`docs/xxx`（不含 `claude`、`ai` 等词）
+- **禁止直接推送到 `dev` 或 `main`**，所有变更必须通过功能分支提 PR 后合并
 
 ### 发版流程（changeset）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,31 @@ npx changeset version # bump versions and update CHANGELOG.md
 
 ---
 
+## Git 工作流规范
+
+### 分支策略
+
+- **所有功能、修复、文档 PR 的目标分支为 `dev`**，不得直接合并到 `main`
+- **`main` 只接受来自 `dev` 的发布 PR**，或紧急 hotfix
+- 分支命名：`feat/xxx`、`fix/xxx`、`docs/xxx`（不含 `claude`、`ai` 等词）
+
+### 发版流程（changeset）
+
+每次发布新版本必须更新 `CHANGELOG.md`：
+
+1. 开发完成后在 `dev` 分支运行：
+   ```bash
+   npx changeset        # 交互式选择 patch/minor/major，填写变更描述
+   npx changeset version # 自动升级 package.json 版本号并写入 CHANGELOG.md
+   ```
+2. 提交 `CHANGELOG.md` 和 `package.json` 的变更到 `dev`
+3. 从 `dev` 向 `main` 提发布 PR
+4. 合并后触发 npm 发布
+
+> **禁止**手动修改版本号或跳过 changeset 步骤发布版本，确保每个版本都有对应的 changelog 条目。
+
+---
+
 ## Architecture
 
 ### Core design principles


### PR DESCRIPTION
## 变更内容

- `CHANGELOG.md` — 补写 1.0.0 完整变更记录，涵盖破坏性变更、新功能、检测能力扩展与构建系统升级
- `CLAUDE.md` — 新增 Git 工作流规范：分支策略（功能 PR → dev，发布 PR → main）及 changeset 发版流程