### PR TITLE
chore: 发布 v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ua-browser
 
+## 1.0.1
+
+### Patch Changes
+
+- 新增浏览器、爬虫、操作系统检测支持，完善文档与国际化
+
+  - 新增浏览器检测：Samsung Internet、DuckDuckGo、Puffin
+  - 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+  - 新增操作系统检测：Tizen、KaiOS
+  - 新增设备类型：TV（智能电视），修复 Android 平板识别缺失
+  - 无头浏览器检测补充 jsdom、Selenium、Playwright 标记
+  - Playground 支持中英文界面切换
+  - 新增完整英文 VitePress 文档站（i18n 双语）
+
 ## 1.0.0
 
 ### Major Changes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # 更新日志
 
+## v1.0.1
+
+### 新增
+
+- 新增浏览器检测：Samsung Internet、DuckDuckGo、Puffin
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增操作系统检测：Tizen、KaiOS
+- 新增设备类型：`TV`（智能电视）
+- 无头浏览器检测补充 jsdom、Selenium、Playwright 标记
+
+### 修复
+
+- Android 设备无 `Mobile` 标记时误判为 PC，现正确识别为平板
+
+### 文档
+
+- Playground 支持中英文界面切换
+- 新增完整英文文档站（VitePress i18n 双语）
+
+---
+
 ## v1.0.0
 
 ### 新增

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v1.0.1
+
+### Added
+
+- Browser detection: Samsung Internet, DuckDuckGo, Puffin
+- AI crawler detection: GPTBot, ClaudeBot, PerplexityBot, CCBot, AdsBot
+- OS detection: Tizen, KaiOS
+- Device type: `TV` (Smart TV)
+- Headless detection: jsdom, Selenium, Playwright markers
+
+### Fixed
+
+- Android devices without `Mobile` marker were incorrectly classified as PC — now correctly identified as Tablet
+
+### Docs
+
+- Playground UI supports Chinese / English switching
+- Full English documentation site (VitePress i18n)
+
+---
+
 ## v1.0.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ua-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## 变更内容

- `package.json` 版本升至 `1.0.1`
- `CHANGELOG.md` 新增 1.0.1 changeset 条目
- `docs/changelog.md` 中文文档同步更新
- `docs/en/changelog.md` 英文文档同步更新

## 1.0.1 变更摘要

### 新增
- 浏览器检测：Samsung Internet、DuckDuckGo、Puffin
- AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
- 操作系统：Tizen、KaiOS
- 设备类型：TV（智能电视）
- 无头浏览器：jsdom、Selenium、Playwright

### 修复
- Android 设备无 `Mobile` 标记时误判为 PC

### 文档
- Playground 中英文切换
- 完整英文文档站（i18n 双语）