### PR TITLE
chore: 发布 v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # ua-browser
 
+## 1.0.0
+
+### Major Changes
+
+**架构重写，全面升级为模块化纯函数设计。**
+
+#### 破坏性变更
+
+- `result.platfrom`（拼写错误）已更正为 `result.platform`
+- 移除 `EnvPart` 类型，统一使用 `EnvOption`
+- 移除单例模式，改为纯函数 `parseUA(ua, options?)`
+
+#### 新增功能
+
+- **`parseUA(ua, options?)`** — 纯函数版本，适用于 SSR / Node.js 环境
+- **`getNavContext()`** — 读取真实 `navigator` 并返回 `NavContext`，Node.js 下安全降级
+- **`getWindowsVersion(nav)`** — 异步精确区分 Windows 10 / 11
+- **`detectBot(ua)`** — 独立爬虫检测器，返回 `{ isBot, botName }`
+- **`detectArch(ua)`** — 独立 CPU 架构检测器
+- **`detectHeadless(ua)`** — 独立无头浏览器检测器
+- **`getLanguage(nav)`** — 从 `NavContext` 提取标准化语言代码
+- **`VERSION`** — 导出当前库版本号
+- 新增命名导出，支持 Tree-shaking
+- 新增 `NavContext` 注入机制，消除全局副作用，所有检测器可在 Node.js 测试
+
+#### 检测能力扩展
+
+- 新增浏览器：Samsung Internet、DuckDuckGo、Puffin
+- 新增操作系统：Tizen、KaiOS
+- 新增设备类型：`TV`（智能电视）
+- 新增 Android 无 `Mobile` 标记时自动识别为平板
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增无头浏览器标记：jsdom、Selenium、Playwright
+
+#### 构建系统
+
+- 从 Rollup + Babel + shelljs 迁移至 **tsup + TypeScript 5**
+- 产物格式：ESM（`.mjs`）、CommonJS（`.cjs`）、IIFE（`.min.js`）、类型声明（`.d.ts` / `.d.cts`）
+- 新增 **Vitest** 测试套件
+
+---
+
 ## 0.1.9
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ua-browser
 
+## 1.0.1
+
+### Patch Changes
+
+- 新增浏览器、爬虫、操作系统检测支持，完善文档与国际化
+
+  - 新增浏览器检测：Samsung Internet、DuckDuckGo、Puffin
+  - 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+  - 新增操作系统检测：Tizen、KaiOS
+  - 新增设备类型：TV（智能电视），修复 Android 平板识别缺失
+  - 无头浏览器检测补充 jsdom、Selenium、Playwright 标记
+  - Playground 支持中英文界面切换
+  - 新增完整英文 VitePress 文档站（i18n 双语）
+
 ## 1.0.0
 
 ### Major Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,32 @@ npx changeset version # bump versions and update CHANGELOG.md
 
 ---
 
+## Git 工作流规范
+
+### 分支策略
+
+- **所有功能、修复、文档 PR 的目标分支为 `dev`**，不得直接合并到 `main`
+- **`main` 只接受来自 `dev` 的发布 PR**，或紧急 hotfix
+- 分支命名：`feat/xxx`、`fix/xxx`、`docs/xxx`（不含 `claude`、`ai` 等词）
+- **禁止直接推送到 `dev` 或 `main`**，所有变更必须通过功能分支提 PR 后合并
+
+### 发版流程（changeset）
+
+每次发布新版本必须更新 `CHANGELOG.md`：
+
+1. 开发完成后在 `dev` 分支运行：
+   ```bash
+   npx changeset        # 交互式选择 patch/minor/major，填写变更描述
+   npx changeset version # 自动升级 package.json 版本号并写入 CHANGELOG.md
+   ```
+2. 提交 `CHANGELOG.md` 和 `package.json` 的变更到 `dev`
+3. 从 `dev` 向 `main` 提发布 PR
+4. 合并后触发 npm 发布
+
+> **禁止**手动修改版本号或跳过 changeset 步骤发布版本，确保每个版本都有对应的 changelog 条目。
+
+---
+
 ## Architecture
 
 ### Core design principles

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -1,5 +1,60 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useData } from 'vitepress'
+
+const { lang } = useData()
+const isEn = computed(() => lang.value === 'en-US')
+
+const i18n = computed(() => isEn.value
+  ? {
+      presetsLabel: 'Presets:',
+      currentBrowser: 'Current Browser',
+      placeholder: 'Enter a User Agent string...',
+      parse: 'Parse',
+      loading: 'Loading...',
+      yes: 'Yes',
+      no: 'No',
+      rawJson: 'Raw JSON',
+      empty: 'Parse result will appear here',
+      fields: {
+        browser: 'Browser',
+        version: 'Version',
+        engine: 'Engine',
+        os: 'OS',
+        device: 'Device',
+        arch: 'Arch',
+        language: 'Language',
+        platform: 'Platform',
+        bot: 'Bot',
+        headless: 'Headless',
+        webview: 'Webview',
+      },
+    }
+  : {
+      presetsLabel: '预设：',
+      currentBrowser: '当前浏览器',
+      placeholder: '输入 User Agent 字符串...',
+      parse: '解析',
+      loading: '加载中...',
+      yes: '是',
+      no: '否',
+      rawJson: '原始 JSON',
+      empty: '解析结果将显示在此处',
+      fields: {
+        browser: '浏览器',
+        version: '版本',
+        engine: '内核',
+        os: '操作系统',
+        device: '设备',
+        arch: '架构',
+        language: '语言',
+        platform: '平台',
+        bot: '爬虫',
+        headless: 'Headless',
+        webview: 'Webview',
+      },
+    }
+)
 
 interface ParseResult {
   browser: string
@@ -102,28 +157,31 @@ function useCurrentUA() {
 const tags = computed(() => {
   if (!result.value) return []
   const r = result.value
+  const t = i18n.value
   const list: { label: string; value: string; type: string }[] = []
   if (r.isBot) list.push({ label: 'Bot', value: r.botName, type: 'danger' })
-  if (r.isHeadless) list.push({ label: 'Headless', value: '是', type: 'warning' })
-  if (r.isWebview) list.push({ label: 'Webview', value: '是', type: 'warning' })
+  if (r.isHeadless) list.push({ label: 'Headless', value: t.yes, type: 'warning' })
+  if (r.isWebview) list.push({ label: 'Webview', value: t.yes, type: 'warning' })
   return list
 })
 
 const fields = computed(() => {
   if (!result.value) return []
   const r = result.value
+  const f = i18n.value.fields
+  const t = i18n.value
   return [
-    { label: '浏览器', value: r.browser },
-    { label: '版本', value: r.version },
-    { label: '内核', value: r.engine },
-    { label: '操作系统', value: `${r.os} ${r.osVersion}`.trim() },
-    { label: '设备', value: r.device },
-    { label: '架构', value: r.arch },
-    { label: '语言', value: r.language },
-    { label: '平台', value: r.platform },
-    { label: '爬虫', value: r.isBot ? r.botName : '否' },
-    { label: 'Headless', value: r.isHeadless ? '是' : '否' },
-    { label: 'Webview', value: r.isWebview ? '是' : '否' },
+    { label: f.browser, value: r.browser },
+    { label: f.version, value: r.version },
+    { label: f.engine, value: r.engine },
+    { label: f.os, value: `${r.os} ${r.osVersion}`.trim() },
+    { label: f.device, value: r.device },
+    { label: f.arch, value: r.arch },
+    { label: f.language, value: r.language },
+    { label: f.platform, value: r.platform },
+    { label: f.bot, value: r.isBot ? r.botName : t.no },
+    { label: f.headless, value: r.isHeadless ? t.yes : t.no },
+    { label: f.webview, value: r.isWebview ? t.yes : t.no },
   ]
 })
 </script>
@@ -132,7 +190,7 @@ const fields = computed(() => {
   <div class="playground">
     <div class="playground-left">
       <div class="playground-presets">
-        <span class="presets-label">预设：</span>
+        <span class="presets-label">{{ i18n.presetsLabel }}</span>
         <button
           v-for="item in PRESET_UAS"
           :key="item.label"
@@ -145,7 +203,7 @@ const fields = computed(() => {
           :class="['preset-btn', 'preset-btn--current', { 'preset-btn--active': selectedKey === 'current' }]"
           @click="useCurrentUA"
         >
-          当前浏览器
+          {{ i18n.currentBrowser }}
         </button>
       </div>
 
@@ -153,14 +211,14 @@ const fields = computed(() => {
         <textarea
           v-model="uaInput"
           class="ua-textarea"
-          placeholder="输入 User Agent 字符串..."
+          :placeholder="i18n.placeholder"
           rows="6"
           spellcheck="false"
           @keydown.enter.ctrl="parse"
           @keydown.enter.meta="parse"
         />
         <button class="parse-btn" :disabled="!loaded" @click="parse">
-          {{ loaded ? '解析' : '加载中...' }}
+          {{ loaded ? i18n.parse : i18n.loading }}
         </button>
       </div>
     </div>
@@ -185,11 +243,11 @@ const fields = computed(() => {
         </div>
 
         <details class="result-raw">
-          <summary>原始 JSON</summary>
+          <summary>{{ i18n.rawJson }}</summary>
           <pre>{{ JSON.stringify(result, null, 2) }}</pre>
         </details>
       </template>
-      <div v-else class="result-empty">解析结果将显示在此处</div>
+      <div v-else class="result-empty">{{ i18n.empty }}</div>
     </div>
   </div>
 </template>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # 更新日志
 
+## v1.0.1
+
+### 新增
+
+- 新增浏览器检测：Samsung Internet、DuckDuckGo、Puffin
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增操作系统检测：Tizen、KaiOS
+- 新增设备类型：`TV`（智能电视）
+- 无头浏览器检测补充 jsdom、Selenium、Playwright 标记
+
+### 修复
+
+- Android 设备无 `Mobile` 标记时误判为 PC，现正确识别为平板
+
+### 文档
+
+- Playground 支持中英文界面切换
+- 新增完整英文文档站（VitePress i18n 双语）
+
+---
+
 ## v1.0.0
 
 ### 新增

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v1.0.1
+
+### Added
+
+- Browser detection: Samsung Internet, DuckDuckGo, Puffin
+- AI crawler detection: GPTBot, ClaudeBot, PerplexityBot, CCBot, AdsBot
+- OS detection: Tizen, KaiOS
+- Device type: `TV` (Smart TV)
+- Headless detection: jsdom, Selenium, Playwright markers
+
+### Fixed
+
+- Android devices without `Mobile` marker were incorrectly classified as PC — now correctly identified as Tablet
+
+### Docs
+
+- Playground UI supports Chinese / English switching
+- Full English documentation site (VitePress i18n)
+
+---
+
 ## v1.0.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ua-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## v1.0.1 发布

### 新增
- 浏览器检测：Samsung Internet、DuckDuckGo、Puffin
- AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
- 操作系统：Tizen、KaiOS
- 设备类型：`TV`（智能电视）
- 无头浏览器：jsdom、Selenium、Playwright 标记

### 修复
- Android 设备无 `Mobile` 标记时误判为 PC，现正确识别为平板

### 文档
- Playground 支持中英文界面切换
- 新增完整英文文档站（VitePress i18n 双语）