### PR TITLE
docs: 文档更新与 CHANGELOG 整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,58 @@
 # ua-browser
 
+## 1.0.1
+
+### Patch Changes
+
+- Added browser, bot, and OS detection support; improved docs and i18n
+
+  - Added browser detection: Samsung Internet, DuckDuckGo, Puffin
+  - Added AI bot detection: GPTBot, ClaudeBot, PerplexityBot, CCBot, AdsBot
+  - Added OS detection: Tizen, KaiOS
+  - Added device type: TV (Smart TV); fixed Android tablet misidentification
+  - Added headless detection markers: jsdom, Selenium, Playwright
+  - Playground supports Chinese / English UI switching
+  - Added full English VitePress documentation site (i18n)
+
 ## 1.0.0
 
 ### Major Changes
 
-**架构重写，全面升级为模块化纯函数设计。**
+**Full architecture rewrite — modular pure-function design.**
 
-#### 破坏性变更
+#### Breaking Changes
 
-- `result.platfrom`（拼写错误）已更正为 `result.platform`
-- 移除 `EnvPart` 类型，统一使用 `EnvOption`
-- 移除单例模式，改为纯函数 `parseUA(ua, options?)`
+- `result.platfrom` (typo) renamed to `result.platform`
+- Removed `EnvPart` type — use `EnvOption` directly
+- Removed singleton class — replaced by pure function `parseUA(ua, options?)`
 
-#### 新增功能
+#### New Features
 
-- **`parseUA(ua, options?)`** — 纯函数版本，适用于 SSR / Node.js 环境
-- **`getNavContext()`** — 读取真实 `navigator` 并返回 `NavContext`，Node.js 下安全降级
-- **`getWindowsVersion(nav)`** — 异步精确区分 Windows 10 / 11
-- **`detectBot(ua)`** — 独立爬虫检测器，返回 `{ isBot, botName }`
-- **`detectArch(ua)`** — 独立 CPU 架构检测器
-- **`detectHeadless(ua)`** — 独立无头浏览器检测器
-- **`getLanguage(nav)`** — 从 `NavContext` 提取标准化语言代码
-- **`VERSION`** — 导出当前库版本号
-- 新增命名导出，支持 Tree-shaking
-- 新增 `NavContext` 注入机制，消除全局副作用，所有检测器可在 Node.js 测试
+- **`parseUA(ua, options?)`** — pure function, ideal for SSR / Node.js
+- **`getNavContext()`** — reads real `navigator`, safely degrades in Node.js
+- **`getWindowsVersion(nav)`** — async accurate Windows 10 / 11 detection
+- **`detectBot(ua)`** — standalone bot detector, returns `{ isBot, botName }`
+- **`detectArch(ua)`** — standalone CPU architecture detector
+- **`detectHeadless(ua)`** — standalone headless browser detector
+- **`getLanguage(nav)`** — extracts normalized language code from `NavContext`
+- **`VERSION`** — exports current library version
+- Named exports with tree-shaking support
+- `NavContext` injection eliminates global side effects; all detectors testable in Node.js
 
-#### 检测能力扩展
+#### Detection Enhancements
 
-- 新增浏览器：Samsung Internet、DuckDuckGo、Puffin
-- 新增操作系统：Tizen、KaiOS
-- 新增设备类型：`TV`（智能电视）
-- 新增 Android 无 `Mobile` 标记时自动识别为平板
-- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
-- 新增无头浏览器标记：jsdom、Selenium、Playwright
+- Added browsers: Samsung Internet, DuckDuckGo, Puffin
+- Added OS: Tizen, KaiOS
+- Added device type: `TV` (Smart TV)
+- Android without `Mobile` marker now correctly identified as Tablet
+- Added AI bot detection: GPTBot, ClaudeBot, PerplexityBot, CCBot, AdsBot
+- Added headless markers: jsdom, Selenium, Playwright
 
-#### 构建系统
+#### Build System
 
-- 从 Rollup + Babel + shelljs 迁移至 **tsup + TypeScript 5**
-- 产物格式：ESM（`.mjs`）、CommonJS（`.cjs`）、IIFE（`.min.js`）、类型声明（`.d.ts` / `.d.cts`）
-- 新增 **Vitest** 测试套件
+- Migrated from Rollup + Babel + shelljs to **tsup + TypeScript 5**
+- Output formats: ESM (`.mjs`), CommonJS (`.cjs`), IIFE (`.min.js`), type declarations (`.d.ts` / `.d.cts`)
+- Added **Vitest** test suite
 
 ---
 
@@ -46,4 +60,4 @@
 
 ### Patch Changes
 
-- fix 修复版本问题
+- Fixed version parsing edge cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # ua-browser
 
+## 1.0.0
+
+### Major Changes
+
+**架构重写，全面升级为模块化纯函数设计。**
+
+#### 破坏性变更
+
+- `result.platfrom`（拼写错误）已更正为 `result.platform`
+- 移除 `EnvPart` 类型，统一使用 `EnvOption`
+- 移除单例模式，改为纯函数 `parseUA(ua, options?)`
+
+#### 新增功能
+
+- **`parseUA(ua, options?)`** — 纯函数版本，适用于 SSR / Node.js 环境
+- **`getNavContext()`** — 读取真实 `navigator` 并返回 `NavContext`，Node.js 下安全降级
+- **`getWindowsVersion(nav)`** — 异步精确区分 Windows 10 / 11
+- **`detectBot(ua)`** — 独立爬虫检测器，返回 `{ isBot, botName }`
+- **`detectArch(ua)`** — 独立 CPU 架构检测器
+- **`detectHeadless(ua)`** — 独立无头浏览器检测器
+- **`getLanguage(nav)`** — 从 `NavContext` 提取标准化语言代码
+- **`VERSION`** — 导出当前库版本号
+- 新增命名导出，支持 Tree-shaking
+- 新增 `NavContext` 注入机制，消除全局副作用，所有检测器可在 Node.js 测试
+
+#### 检测能力扩展
+
+- 新增浏览器：Samsung Internet、DuckDuckGo、Puffin
+- 新增操作系统：Tizen、KaiOS
+- 新增设备类型：`TV`（智能电视）
+- 新增 Android 无 `Mobile` 标记时自动识别为平板
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增无头浏览器标记：jsdom、Selenium、Playwright
+
+#### 构建系统
+
+- 从 Rollup + Babel + shelljs 迁移至 **tsup + TypeScript 5**
+- 产物格式：ESM（`.mjs`）、CommonJS（`.cjs`）、IIFE（`.min.js`）、类型声明（`.d.ts` / `.d.cts`）
+- 新增 **Vitest** 测试套件
+
+---
+
 ## 0.1.9
 
 ### Patch Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,0 +1,63 @@
+# ua-browser
+
+## 1.0.1
+
+### Patch Changes
+
+- 新增浏览器、爬虫、操作系统检测支持，完善文档与国际化
+
+  - 新增浏览器检测：Samsung Internet、DuckDuckGo、Puffin
+  - 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+  - 新增操作系统检测：Tizen、KaiOS
+  - 新增设备类型：TV（智能电视），修复 Android 平板识别缺失
+  - 无头浏览器检测补充 jsdom、Selenium、Playwright 标记
+  - Playground 支持中英文界面切换
+  - 新增完整英文 VitePress 文档站（i18n 双语）
+
+## 1.0.0
+
+### Major Changes
+
+**架构重写，全面升级为模块化纯函数设计。**
+
+#### 破坏性变更
+
+- \`result.platfrom\`（拼写错误）已更正为 \`result.platform\`
+- 移除 \`EnvPart\` 类型，统一使用 \`EnvOption\`
+- 移除单例模式，改为纯函数 \`parseUA(ua, options?)\`
+
+#### 新增功能
+
+- **\`parseUA(ua, options?)\`** — 纯函数版本，适用于 SSR / Node.js 环境
+- **\`getNavContext()\`** — 读取真实 \`navigator\` 并返回 \`NavContext\`，Node.js 下安全降级
+- **\`getWindowsVersion(nav)\`** — 异步精确区分 Windows 10 / 11
+- **\`detectBot(ua)\`** — 独立爬虫检测器，返回 \`{ isBot, botName }\`
+- **\`detectArch(ua)\`** — 独立 CPU 架构检测器
+- **\`detectHeadless(ua)\`** — 独立无头浏览器检测器
+- **\`getLanguage(nav)\`** — 从 \`NavContext\` 提取标准化语言代码
+- **\`VERSION\`** — 导出当前库版本号
+- 新增命名导出，支持 Tree-shaking
+- 新增 \`NavContext\` 注入机制，消除全局副作用，所有检测器可在 Node.js 测试
+
+#### 检测能力扩展
+
+- 新增浏览器：Samsung Internet、DuckDuckGo、Puffin
+- 新增操作系统：Tizen、KaiOS
+- 新增设备类型：\`TV\`（智能电视）
+- 新增 Android 无 \`Mobile\` 标记时自动识别为平板
+- 新增 AI 爬虫检测：GPTBot、ClaudeBot、PerplexityBot、CCBot、AdsBot
+- 新增无头浏览器标记：jsdom、Selenium、Playwright
+
+#### 构建系统
+
+- 从 Rollup + Babel + shelljs 迁移至 **tsup + TypeScript 5**
+- 产物格式：ESM（\`.mjs\`）、CommonJS（\`.cjs\`）、IIFE（\`.min.js\`）、类型声明（\`.d.ts\` / \`.d.cts\`）
+- 新增 **Vitest** 测试套件
+
+---
+
+## 0.1.9
+
+### Patch Changes
+
+- 修复版本解析边界问题

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,32 @@ npx changeset version # bump versions and update CHANGELOG.md
 
 ---
 
+## Git 工作流规范
+
+### 分支策略
+
+- **所有功能、修复、文档 PR 的目标分支为 `dev`**，不得直接合并到 `main`
+- **`main` 只接受来自 `dev` 的发布 PR**，或紧急 hotfix
+- 分支命名：`feat/xxx`、`fix/xxx`、`docs/xxx`（不含 `claude`、`ai` 等词）
+- **禁止直接推送到 `dev` 或 `main`**，所有变更必须通过功能分支提 PR 后合并
+
+### 发版流程（changeset）
+
+每次发布新版本必须更新 `CHANGELOG.md`：
+
+1. 开发完成后在 `dev` 分支运行：
+   ```bash
+   npx changeset        # 交互式选择 patch/minor/major，填写变更描述
+   npx changeset version # 自动升级 package.json 版本号并写入 CHANGELOG.md
+   ```
+2. 提交 `CHANGELOG.md` 和 `package.json` 的变更到 `dev`
+3. 从 `dev` 向 `main` 提发布 PR
+4. 合并后触发 npm 发布
+
+> **禁止**手动修改版本号或跳过 changeset 步骤发布版本，确保每个版本都有对应的 changelog 条目。
+
+---
+
 ## Architecture
 
 ### Core design principles

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -1,5 +1,60 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useData } from 'vitepress'
+
+const { lang } = useData()
+const isEn = computed(() => lang.value === 'en-US')
+
+const i18n = computed(() => isEn.value
+  ? {
+      presetsLabel: 'Presets:',
+      currentBrowser: 'Current Browser',
+      placeholder: 'Enter a User Agent string...',
+      parse: 'Parse',
+      loading: 'Loading...',
+      yes: 'Yes',
+      no: 'No',
+      rawJson: 'Raw JSON',
+      empty: 'Parse result will appear here',
+      fields: {
+        browser: 'Browser',
+        version: 'Version',
+        engine: 'Engine',
+        os: 'OS',
+        device: 'Device',
+        arch: 'Arch',
+        language: 'Language',
+        platform: 'Platform',
+        bot: 'Bot',
+        headless: 'Headless',
+        webview: 'Webview',
+      },
+    }
+  : {
+      presetsLabel: '预设：',
+      currentBrowser: '当前浏览器',
+      placeholder: '输入 User Agent 字符串...',
+      parse: '解析',
+      loading: '加载中...',
+      yes: '是',
+      no: '否',
+      rawJson: '原始 JSON',
+      empty: '解析结果将显示在此处',
+      fields: {
+        browser: '浏览器',
+        version: '版本',
+        engine: '内核',
+        os: '操作系统',
+        device: '设备',
+        arch: '架构',
+        language: '语言',
+        platform: '平台',
+        bot: '爬虫',
+        headless: 'Headless',
+        webview: 'Webview',
+      },
+    }
+)
 
 interface ParseResult {
   browser: string
@@ -102,28 +157,31 @@ function useCurrentUA() {
 const tags = computed(() => {
   if (!result.value) return []
   const r = result.value
+  const t = i18n.value
   const list: { label: string; value: string; type: string }[] = []
   if (r.isBot) list.push({ label: 'Bot', value: r.botName, type: 'danger' })
-  if (r.isHeadless) list.push({ label: 'Headless', value: '是', type: 'warning' })
-  if (r.isWebview) list.push({ label: 'Webview', value: '是', type: 'warning' })
+  if (r.isHeadless) list.push({ label: 'Headless', value: t.yes, type: 'warning' })
+  if (r.isWebview) list.push({ label: 'Webview', value: t.yes, type: 'warning' })
   return list
 })
 
 const fields = computed(() => {
   if (!result.value) return []
   const r = result.value
+  const f = i18n.value.fields
+  const t = i18n.value
   return [
-    { label: '浏览器', value: r.browser },
-    { label: '版本', value: r.version },
-    { label: '内核', value: r.engine },
-    { label: '操作系统', value: `${r.os} ${r.osVersion}`.trim() },
-    { label: '设备', value: r.device },
-    { label: '架构', value: r.arch },
-    { label: '语言', value: r.language },
-    { label: '平台', value: r.platform },
-    { label: '爬虫', value: r.isBot ? r.botName : '否' },
-    { label: 'Headless', value: r.isHeadless ? '是' : '否' },
-    { label: 'Webview', value: r.isWebview ? '是' : '否' },
+    { label: f.browser, value: r.browser },
+    { label: f.version, value: r.version },
+    { label: f.engine, value: r.engine },
+    { label: f.os, value: `${r.os} ${r.osVersion}`.trim() },
+    { label: f.device, value: r.device },
+    { label: f.arch, value: r.arch },
+    { label: f.language, value: r.language },
+    { label: f.platform, value: r.platform },
+    { label: f.bot, value: r.isBot ? r.botName : t.no },
+    { label: f.headless, value: r.isHeadless ? t.yes : t.no },
+    { label: f.webview, value: r.isWebview ? t.yes : t.no },
   ]
 })
 </script>
@@ -132,7 +190,7 @@ const fields = computed(() => {
   <div class="playground">
     <div class="playground-left">
       <div class="playground-presets">
-        <span class="presets-label">预设：</span>
+        <span class="presets-label">{{ i18n.presetsLabel }}</span>
         <button
           v-for="item in PRESET_UAS"
           :key="item.label"
@@ -145,7 +203,7 @@ const fields = computed(() => {
           :class="['preset-btn', 'preset-btn--current', { 'preset-btn--active': selectedKey === 'current' }]"
           @click="useCurrentUA"
         >
-          当前浏览器
+          {{ i18n.currentBrowser }}
         </button>
       </div>
 
@@ -153,14 +211,14 @@ const fields = computed(() => {
         <textarea
           v-model="uaInput"
           class="ua-textarea"
-          placeholder="输入 User Agent 字符串..."
+          :placeholder="i18n.placeholder"
           rows="6"
           spellcheck="false"
           @keydown.enter.ctrl="parse"
           @keydown.enter.meta="parse"
         />
         <button class="parse-btn" :disabled="!loaded" @click="parse">
-          {{ loaded ? '解析' : '加载中...' }}
+          {{ loaded ? i18n.parse : i18n.loading }}
         </button>
       </div>
     </div>
@@ -185,11 +243,11 @@ const fields = computed(() => {
         </div>
 
         <details class="result-raw">
-          <summary>原始 JSON</summary>
+          <summary>{{ i18n.rawJson }}</summary>
           <pre>{{ JSON.stringify(result, null, 2) }}</pre>
         </details>
       </template>
-      <div v-else class="result-empty">解析结果将显示在此处</div>
+      <div v-else class="result-empty">{{ i18n.empty }}</div>
     </div>
   </div>
 </template>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,36 +1,5 @@
-# 更新日志
-
-## v1.0.0
-
-### 新增
-
-- 爬虫检测：`isBot`、`botName` 字段，支持 18 种主流爬虫
-- CPU 架构检测：`arch` 字段（`x86` / `x86_64` / `arm` / `arm64`）
-- 无头浏览器检测：`isHeadless` 字段（HeadlessChrome、PhantomJS、Electron、Playwright）
-- 命名导出：`parseUA`、`detectBot`、`detectArch`、`detectHeadless` 等，支持 tree-shaking
-
-### 变更
-
-- `device: 'Pc'` → `device: 'PC'`
-- `result.platfrom` → `result.platform`（修正拼写错误）
-- 移除 `EnvPart` 类型，统一使用 `EnvOption`
-
-### 重构
-
-- 架构拆分为 `constants/`、`detectors/`、`utils/` 模块
-- 纯函数 `parseUA()` 替代单例类，消除状态突变
-- TypeScript 升级至 5.x，构建工具迁移至 tsup
-
+---
+title: 更新日志
 ---
 
-## v0.1.9
-
-修复部分边界 UA 识别问题。
-
-## v0.1.7
-
-新增 Webview 检测支持。
-
-## v0.1.0
-
-初始版本发布。
+<!--@include: ../CHANGELOG.zh-CN.md-->

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,36 +1,5 @@
-# Changelog
-
-## v1.0.0
-
-### Added
-
-- Bot detection: `isBot` and `botName` fields with 18+ major crawlers supported
-- CPU architecture detection: `arch` field (`x86` / `x86_64` / `arm` / `arm64`)
-- Headless browser detection: `isHeadless` field (HeadlessChrome, PhantomJS, Electron, Playwright)
-- Named exports: `parseUA`, `detectBot`, `detectArch`, `detectHeadless` and more — tree-shakeable
-
-### Changed
-
-- `device: 'Pc'` → `device: 'PC'`
-- `result.platfrom` → `result.platform` (typo fix)
-- Removed `EnvPart` type — use `EnvOption` directly
-
-### Refactored
-
-- Architecture split into `constants/`, `detectors/`, `utils/` modules
-- Pure function `parseUA()` replaces singleton class, eliminating state mutation
-- Upgraded to TypeScript 5.x, migrated build tooling to tsup
-
+---
+title: Changelog
 ---
 
-## v0.1.9
-
-Fixed edge-case UA parsing issues.
-
-## v0.1.7
-
-Added Webview detection support.
-
-## v0.1.0
-
-Initial release.
+<!--@include: ../../CHANGELOG.md-->


### PR DESCRIPTION
## 变更内容

- Playground 组件支持中英文国际化
- 补写 1.0.0 changelog，新增 Git 工作流规范到 CLAUDE.md
- CHANGELOG 拆分为英文主版本（`CHANGELOG.md`）与中文版（`CHANGELOG.zh-CN.md`），文档页面通过 `<!--@include-->` 自动引入，无需单独维护