### PR TITLE
fix: 修复 OS 检测顺序及 iOS Safari 版本误判

### DIFF
--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -454,6 +454,8 @@ const fields = computed(() => {
 @media (max-width: 768px) {
   .playground {
     flex-direction: column;
+    padding: 12px;
+    gap: 16px;
   }
 
   .playground-left {

--- a/src/constants/os.ts
+++ b/src/constants/os.ts
@@ -9,27 +9,35 @@ export interface OsDef {
   versionLookup?: Record<string, string>
 }
 
+// Detection uses last-match-wins: entries that appear later override earlier matches.
+// More specific OS entries must come AFTER the generic ones they supersede.
 export const OS_DEFS: readonly OsDef[] = [
   { name: 'WebOS',          detect: /hpwOS/,                          versionPattern: /hpwOS\/([\d.]+)/ },
   { name: 'Symbian',        detect: /Symbian/,                        versionPattern: null },
   { name: 'MeeGo',          detect: /MeeGo/,                          versionPattern: null },
   { name: 'BlackBerry',     detect: /(BlackBerry|RIM)/,               versionPattern: null },
-  { name: 'Windows Phone',  detect: /(IEMobile|Windows Phone)/,       versionPattern: /Windows Phone(?: OS)? ([\d.]+)/ },
   { name: 'FreeBSD',        detect: /FreeBSD/,                        versionPattern: null },
   { name: 'Debian',         detect: /Debian/,                         versionPattern: /Debian\/([\d.]+)/ },
   { name: 'Ubuntu',         detect: /Ubuntu/,                         versionPattern: null },
-  { name: 'Chrome OS',      detect: /CrOS/,                           versionPattern: null },
+  // Linux must come before Chrome OS: Chrome OS UAs contain "X11", so Linux matches first,
+  // then Chrome OS overrides it.
   { name: 'Linux',          detect: /(Linux|X11)/,                    versionPattern: null },
+  { name: 'Chrome OS',      detect: /CrOS/,                           versionPattern: null },
   { name: 'Tizen',          detect: /Tizen/,                          versionPattern: /Tizen ([\d.]+)/ },
   { name: 'iOS',            detect: /like Mac OS X/,                  versionPattern: /OS ([\d_]+) like/ },
   { name: 'MacOS',          detect: /Macintosh/,                      versionPattern: /Mac OS X -?([\d_.]+)/ },
+  { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
+  // HarmonyOS must come after Android: HarmonyOS UAs include "Android", so Android matches
+  // first, then HarmonyOS overrides it.
   { name: 'HarmonyOS',      detect: /HarmonyOS/,                      versionPattern: /Android ([\d.]+)[;)]/,
     versionLookup: { '10': '2' } },
-  { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
   { name: 'KaiOS',          detect: /KAIOS/,                          versionPattern: /KAIOS\/([\d.]+)/ },
+  // Windows must come before Windows Phone: Windows Phone UAs contain "Windows", so Windows
+  // matches first, then Windows Phone overrides it.
   { name: 'Windows',        detect: /Windows/,                        versionPattern: /Windows NT ([\d.]+)/,
     versionLookup: {
       '10': '10', '6.4': '10', '6.3': '8.1', '6.2': '8',
       '6.1': '7', '6.0': 'Vista', '5.2': 'XP', '5.1': 'XP', '5.0': '2000'
-    } }
+    } },
+  { name: 'Windows Phone',  detect: /(IEMobile|Windows Phone)/,       versionPattern: /Windows Phone(?: OS)? ([\d.]+)/ },
 ] as const

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -25,7 +25,8 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
   const { nav, windowsVersion } = options
 
   const { browser: rawBrowser, version: rawVersion } = detectBrowser(ua)
-  const { os, osVersion } = detectOs(ua, windowsVersion)
+  const { os, osVersion: rawOsVersion } = detectOs(ua, windowsVersion)
+  let osVersion = rawOsVersion
   const device = detectDevice(ua, nav)
   const arch = detectArch(ua)
   const { isBot, botName } = detectBot(ua)
@@ -120,6 +121,16 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
       }
     } catch {
       // not in WeChat miniapp context
+    }
+  }
+
+  // iOS 26+: Apple freezes "CPU iPhone OS" at the last iOS 18 value for web compatibility.
+  // The Version/ token reliably reflects the real Safari/iOS version.
+  // When Version/ major > CPU iPhone OS major, use Version/ as the real osVersion.
+  if (os === 'iOS' && browser === 'Safari') {
+    const m = /Version\/([\d.]+)/.exec(ua)
+    if (m && parseInt(m[1], 10) > parseInt(osVersion, 10)) {
+      osVersion = m[1]
     }
   }
 

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -16,6 +16,12 @@ describe('detectBrowser', () => {
       expect(r.version).toBe('124.0.6367.88')
     })
 
+    it('detects Chrome iOS 26 (CriOS)', () => {
+      const r = detectBrowser(UA.chrome.crios26)
+      expect(r.browser).toBe('Chrome')
+      expect(r.version).toBe('147.0.7727.99')
+    })
+
     it('detects Edge Chromium', () => {
       const r = detectBrowser(UA.edge.chromium)
       expect(r.browser).toBe('Edge')
@@ -68,6 +74,12 @@ describe('detectBrowser', () => {
       const r = detectBrowser(UA.safari.ios)
       expect(r.browser).toBe('Safari')
       expect(r.version).toBe('17.4')
+    })
+
+    it('detects Safari iOS 26 (decoupled version)', () => {
+      const r = detectBrowser(UA.safari.ios26)
+      expect(r.browser).toBe('Safari')
+      expect(r.version).toBe('26.4')
     })
 
     it('detects IE11', () => {

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -5,6 +5,7 @@ export const UA = {
     mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
     android: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
     crios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.6367.88 Mobile/15E148 Safari/604.1',
+    crios26: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/147.0.7727.99 Mobile/15E148 Safari/604.1',
     old26: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.64 Safari/537.31'
   },
   edge: {
@@ -21,7 +22,9 @@ export const UA = {
   safari: {
     desktop: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15',
     ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
-    ipad: 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+    ipad: 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+    // iOS 26+: Apple freezes CPU iPhone OS at 18_7; Version/ carries the real version
+    ios26: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Mobile/15E148 Safari/604.1'
   },
   ie: {
     ie11: 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',

--- a/test/os.test.ts
+++ b/test/os.test.ts
@@ -66,6 +66,26 @@ describe('detectOs', () => {
     expect(r.osVersion).toBe('2.5.2')
   })
 
+  it('Chrome OS → Chrome OS (not misidentified as Linux via X11)', () => {
+    const ua = 'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+    const r = detectOs(ua)
+    expect(r.os).toBe('Chrome OS')
+  })
+
+  it('Windows Phone → Windows Phone (not misidentified as Windows)', () => {
+    const ua = 'Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254'
+    const r = detectOs(ua)
+    expect(r.os).toBe('Windows Phone')
+    expect(r.osVersion).toBe('10.0')
+  })
+
+  it('HarmonyOS → HarmonyOS (not misidentified as Android)', () => {
+    const ua = 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ANA-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 HuaweiBrowser/11.0.8.301 Mobile Safari/537.36'
+    const r = detectOs(ua)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('2')
+  })
+
   it('returns unknown for empty UA', () => {
     const r = detectOs('')
     expect(r.os).toBe('unknown')

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -49,6 +49,27 @@ describe('parseUA — full pipeline', () => {
     const r = parseUA(UA.safari.ios)
     expect(r.browser).toBe('Safari')
     expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('17.4')
+    expect(r.engine).toBe('WebKit')
+    expect(r.device).toBe('Mobile')
+  })
+
+  it('Safari on iOS 26 — CPU iPhone OS frozen at 18_7, Version/ reflects real version', () => {
+    const r = parseUA(UA.safari.ios26)
+    expect(r.browser).toBe('Safari')
+    expect(r.version).toBe('26.4')
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.4')
+    expect(r.engine).toBe('WebKit')
+    expect(r.device).toBe('Mobile')
+  })
+
+  it('Chrome on iOS 26 — CriOS reports real OS version', () => {
+    const r = parseUA(UA.chrome.crios26)
+    expect(r.browser).toBe('Chrome')
+    expect(r.version).toBe('147.0.7727.99')
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.4.2')
     expect(r.engine).toBe('WebKit')
     expect(r.device).toBe('Mobile')
   })


### PR DESCRIPTION
## 问题

`OS_DEFS` 使用后匹配覆盖前匹配的机制，三处顺序错误导致 OS 误判；iOS 26+ Safari UA 中 `CPU iPhone OS` 被 Apple 冻结导致版本显示错误。

## 修复内容

**OS 检测顺序（`src/constants/os.ts`）**

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| Chrome OS UA 含 `X11` | 识别为 Linux | 识别为 Chrome OS |
| HarmonyOS UA 含 `Android` | 识别为 Android | 识别为 HarmonyOS |
| Windows Phone UA 含 `Windows` | 识别为 Windows | 识别为 Windows Phone |

**iOS Safari 版本（`src/parse.ts`）**

iOS 26+ 中 Apple 将 Safari UA 里的 `CPU iPhone OS` 冻结在 `18_7`，真实版本通过 `Version/` 体现。当 `Version/` 主版本号 > `CPU iPhone OS` 主版本号时，改用 `Version/` 的值作为 `osVersion`。

**Playground 手机端布局（`docs/`）**

手机端 padding 从 24px 缩减至 12px，结果网格恢复两列显示。

## 测试

新增 8 个测试用例，158 个测试全部通过。