### PR TITLE
chore: 发布 v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ua-browser
 
+## 1.0.2
+
+### Patch Changes
+
+- Fix OS detection order bugs and iOS Safari version parsing
+
+  - Fix Chrome OS misidentified as Linux (Chrome OS UA contains X11)
+  - Fix HarmonyOS misidentified as Android (HarmonyOS UA contains Android)
+  - Fix Windows Phone misidentified as Windows (Windows Phone UA contains Windows)
+  - Fix iOS 26+ Safari osVersion showing frozen value (18.7) instead of real version from Version/ token
+  - Fix Playground mobile layout: reduce padding for two-column result grid on small screens
+
 ## 1.0.1
 
 ### Patch Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,17 @@
 # ua-browser
 
+## 1.0.2
+
+### Patch Changes
+
+- 修复 OS 检测顺序及 iOS Safari 版本误判
+
+  - 修复 Chrome OS 被误识别为 Linux（Chrome OS UA 含 X11）
+  - 修复 HarmonyOS 被误识别为 Android（HarmonyOS UA 含 Android）
+  - 修复 Windows Phone 被误识别为 Windows（Windows Phone UA 含 Windows）
+  - 修复 iOS 26+ Safari osVersion 显示冻结值（18.7）而非 Version/ 真实版本
+  - 修复 Playground 手机端边距过大导致结果只显示一列的问题
+
 ## 1.0.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ua-browser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## v1.0.2

### Patch Changes

- 修复 Chrome OS 被误识别为 Linux（Chrome OS UA 含 X11）
- 修复 HarmonyOS 被误识别为 Android（HarmonyOS UA 含 Android）
- 修复 Windows Phone 被误识别为 Windows（Windows Phone UA 含 Windows）
- 修复 iOS 26+ Safari `osVersion` 显示冻结值而非 `Version/` 真实版本
- 修复 Playground 手机端边距过大导致结果只显示一列