### PR TITLE
chore: 发布 v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ua-browser
 
+## 1.0.2
+
+### Patch Changes
+
+- Fix OS detection order bugs and iOS Safari version parsing
+
+  - Fix Chrome OS misidentified as Linux (Chrome OS UA contains X11)
+  - Fix HarmonyOS misidentified as Android (HarmonyOS UA contains Android)
+  - Fix Windows Phone misidentified as Windows (Windows Phone UA contains Windows)
+  - Fix iOS 26+ Safari osVersion showing frozen value (18.7) instead of real version from Version/ token
+  - Fix Playground mobile layout: reduce padding for two-column result grid on small screens
+
 ## 1.0.1
 
 ### Patch Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,17 @@
 # ua-browser
 
+## 1.0.2
+
+### Patch Changes
+
+- 修复 OS 检测顺序及 iOS Safari 版本误判
+
+  - 修复 Chrome OS 被误识别为 Linux（Chrome OS UA 含 X11）
+  - 修复 HarmonyOS 被误识别为 Android（HarmonyOS UA 含 Android）
+  - 修复 Windows Phone 被误识别为 Windows（Windows Phone UA 含 Windows）
+  - 修复 iOS 26+ Safari osVersion 显示冻结值（18.7）而非 Version/ 真实版本
+  - 修复 Playground 手机端边距过大导致结果只显示一列的问题
+
 ## 1.0.1
 
 ### Patch Changes

--- a/docs/.vitepress/theme/components/Playground.vue
+++ b/docs/.vitepress/theme/components/Playground.vue
@@ -454,6 +454,8 @@ const fields = computed(() => {
 @media (max-width: 768px) {
   .playground {
     flex-direction: column;
+    padding: 12px;
+    gap: 16px;
   }
 
   .playground-left {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ua-browser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/constants/os.ts
+++ b/src/constants/os.ts
@@ -9,27 +9,35 @@ export interface OsDef {
   versionLookup?: Record<string, string>
 }
 
+// Detection uses last-match-wins: entries that appear later override earlier matches.
+// More specific OS entries must come AFTER the generic ones they supersede.
 export const OS_DEFS: readonly OsDef[] = [
   { name: 'WebOS',          detect: /hpwOS/,                          versionPattern: /hpwOS\/([\d.]+)/ },
   { name: 'Symbian',        detect: /Symbian/,                        versionPattern: null },
   { name: 'MeeGo',          detect: /MeeGo/,                          versionPattern: null },
   { name: 'BlackBerry',     detect: /(BlackBerry|RIM)/,               versionPattern: null },
-  { name: 'Windows Phone',  detect: /(IEMobile|Windows Phone)/,       versionPattern: /Windows Phone(?: OS)? ([\d.]+)/ },
   { name: 'FreeBSD',        detect: /FreeBSD/,                        versionPattern: null },
   { name: 'Debian',         detect: /Debian/,                         versionPattern: /Debian\/([\d.]+)/ },
   { name: 'Ubuntu',         detect: /Ubuntu/,                         versionPattern: null },
-  { name: 'Chrome OS',      detect: /CrOS/,                           versionPattern: null },
+  // Linux must come before Chrome OS: Chrome OS UAs contain "X11", so Linux matches first,
+  // then Chrome OS overrides it.
   { name: 'Linux',          detect: /(Linux|X11)/,                    versionPattern: null },
+  { name: 'Chrome OS',      detect: /CrOS/,                           versionPattern: null },
   { name: 'Tizen',          detect: /Tizen/,                          versionPattern: /Tizen ([\d.]+)/ },
   { name: 'iOS',            detect: /like Mac OS X/,                  versionPattern: /OS ([\d_]+) like/ },
   { name: 'MacOS',          detect: /Macintosh/,                      versionPattern: /Mac OS X -?([\d_.]+)/ },
+  { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
+  // HarmonyOS must come after Android: HarmonyOS UAs include "Android", so Android matches
+  // first, then HarmonyOS overrides it.
   { name: 'HarmonyOS',      detect: /HarmonyOS/,                      versionPattern: /Android ([\d.]+)[;)]/,
     versionLookup: { '10': '2' } },
-  { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
   { name: 'KaiOS',          detect: /KAIOS/,                          versionPattern: /KAIOS\/([\d.]+)/ },
+  // Windows must come before Windows Phone: Windows Phone UAs contain "Windows", so Windows
+  // matches first, then Windows Phone overrides it.
   { name: 'Windows',        detect: /Windows/,                        versionPattern: /Windows NT ([\d.]+)/,
     versionLookup: {
       '10': '10', '6.4': '10', '6.3': '8.1', '6.2': '8',
       '6.1': '7', '6.0': 'Vista', '5.2': 'XP', '5.1': 'XP', '5.0': '2000'
-    } }
+    } },
+  { name: 'Windows Phone',  detect: /(IEMobile|Windows Phone)/,       versionPattern: /Windows Phone(?: OS)? ([\d.]+)/ },
 ] as const

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -25,7 +25,8 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
   const { nav, windowsVersion } = options
 
   const { browser: rawBrowser, version: rawVersion } = detectBrowser(ua)
-  const { os, osVersion } = detectOs(ua, windowsVersion)
+  const { os, osVersion: rawOsVersion } = detectOs(ua, windowsVersion)
+  let osVersion = rawOsVersion
   const device = detectDevice(ua, nav)
   const arch = detectArch(ua)
   const { isBot, botName } = detectBot(ua)
@@ -120,6 +121,16 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
       }
     } catch {
       // not in WeChat miniapp context
+    }
+  }
+
+  // iOS 26+: Apple freezes "CPU iPhone OS" at the last iOS 18 value for web compatibility.
+  // The Version/ token reliably reflects the real Safari/iOS version.
+  // When Version/ major > CPU iPhone OS major, use Version/ as the real osVersion.
+  if (os === 'iOS' && browser === 'Safari') {
+    const m = /Version\/([\d.]+)/.exec(ua)
+    if (m && parseInt(m[1], 10) > parseInt(osVersion, 10)) {
+      osVersion = m[1]
     }
   }
 

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -16,6 +16,12 @@ describe('detectBrowser', () => {
       expect(r.version).toBe('124.0.6367.88')
     })
 
+    it('detects Chrome iOS 26 (CriOS)', () => {
+      const r = detectBrowser(UA.chrome.crios26)
+      expect(r.browser).toBe('Chrome')
+      expect(r.version).toBe('147.0.7727.99')
+    })
+
     it('detects Edge Chromium', () => {
       const r = detectBrowser(UA.edge.chromium)
       expect(r.browser).toBe('Edge')
@@ -68,6 +74,12 @@ describe('detectBrowser', () => {
       const r = detectBrowser(UA.safari.ios)
       expect(r.browser).toBe('Safari')
       expect(r.version).toBe('17.4')
+    })
+
+    it('detects Safari iOS 26 (decoupled version)', () => {
+      const r = detectBrowser(UA.safari.ios26)
+      expect(r.browser).toBe('Safari')
+      expect(r.version).toBe('26.4')
     })
 
     it('detects IE11', () => {

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -5,6 +5,7 @@ export const UA = {
     mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
     android: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
     crios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.6367.88 Mobile/15E148 Safari/604.1',
+    crios26: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/147.0.7727.99 Mobile/15E148 Safari/604.1',
     old26: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.64 Safari/537.31'
   },
   edge: {
@@ -21,7 +22,9 @@ export const UA = {
   safari: {
     desktop: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15',
     ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
-    ipad: 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+    ipad: 'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+    // iOS 26+: Apple freezes CPU iPhone OS at 18_7; Version/ carries the real version
+    ios26: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Mobile/15E148 Safari/604.1'
   },
   ie: {
     ie11: 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',

--- a/test/os.test.ts
+++ b/test/os.test.ts
@@ -66,6 +66,26 @@ describe('detectOs', () => {
     expect(r.osVersion).toBe('2.5.2')
   })
 
+  it('Chrome OS → Chrome OS (not misidentified as Linux via X11)', () => {
+    const ua = 'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+    const r = detectOs(ua)
+    expect(r.os).toBe('Chrome OS')
+  })
+
+  it('Windows Phone → Windows Phone (not misidentified as Windows)', () => {
+    const ua = 'Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254'
+    const r = detectOs(ua)
+    expect(r.os).toBe('Windows Phone')
+    expect(r.osVersion).toBe('10.0')
+  })
+
+  it('HarmonyOS → HarmonyOS (not misidentified as Android)', () => {
+    const ua = 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ANA-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 HuaweiBrowser/11.0.8.301 Mobile Safari/537.36'
+    const r = detectOs(ua)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('2')
+  })
+
   it('returns unknown for empty UA', () => {
     const r = detectOs('')
     expect(r.os).toBe('unknown')

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -49,6 +49,27 @@ describe('parseUA — full pipeline', () => {
     const r = parseUA(UA.safari.ios)
     expect(r.browser).toBe('Safari')
     expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('17.4')
+    expect(r.engine).toBe('WebKit')
+    expect(r.device).toBe('Mobile')
+  })
+
+  it('Safari on iOS 26 — CPU iPhone OS frozen at 18_7, Version/ reflects real version', () => {
+    const r = parseUA(UA.safari.ios26)
+    expect(r.browser).toBe('Safari')
+    expect(r.version).toBe('26.4')
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.4')
+    expect(r.engine).toBe('WebKit')
+    expect(r.device).toBe('Mobile')
+  })
+
+  it('Chrome on iOS 26 — CriOS reports real OS version', () => {
+    const r = parseUA(UA.chrome.crios26)
+    expect(r.browser).toBe('Chrome')
+    expect(r.version).toBe('147.0.7727.99')
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.4.2')
     expect(r.engine).toBe('WebKit')
     expect(r.device).toBe('Mobile')
   })


### PR DESCRIPTION
## v1.0.2

### Patch Changes

- 修复 Chrome OS 被误识别为 Linux（Chrome OS UA 含 X11）
- 修复 HarmonyOS 被误识别为 Android（HarmonyOS UA 含 Android）
- 修复 Windows Phone 被误识别为 Windows（Windows Phone UA 含 Windows）
- 修复 iOS 26+ Safari `osVersion` 显示冻结值而非 `Version/` 真实版本
- 修复 Playground 手机端边距过大导致结果只显示一列