### PR TITLE
feat: v1.1.0 多信号融合检测与鸿蒙检测增强

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # ua-browser
 
+## 1.1.0
+
+### Minor Changes
+
+- 新增多信号融合检测架构（v1.1.0）：
+
+  - `getEnvContext()` 一次性采集所有浏览器环境信号（WebGL、Client Hints、字体探针、CSS media features）
+  - `ParseOptions.ctx` 新选项，将 EnvContext 传入 parseUA() 以启用多信号检测
+  - `parseHeaders()` + `ACCEPT_CH` 常量：服务端通过 HTTP Client Hints 头部实现精准检测（SSR 场景）
+  - `detectArch()` 升级为四层优先级链（Client Hints → WebGL → platform → UA 字符串）
+  - `isWebview()` 新增 iOS WKWebView 检测（补充 Android `;wv` 现有逻辑）
+  - HarmonyOS Next（5.0+）版本直接提取，无需依赖 Android 兼容层版本号
+  - 新增 HarmonyOS 版本映射（Android 11→3、12→3、13→4）
+  - 新增 OpenHarmony OS 检测（独立 OsName）
+  - 新增 ArkWeb 引擎检测
+
 ## 1.0.2
 
 ### Patch Changes

--- a/docs/en/guide/support-list.md
+++ b/docs/en/guide/support-list.md
@@ -87,7 +87,8 @@ WeChat Mini Programs are detected separately via `isWechatMiniapp()` (relies on 
 | Android | `Android` | `14`, `13`, `12`... |
 | iOS | `iOS` | `17.4`, `16.0`... |
 | macOS | `MacOS` | `10.15.7`... |
-| HarmonyOS | `HarmonyOS` | `2` (mapped from Android version) |
+| HarmonyOS | `HarmonyOS` | `2`, `3`, `4` (mapped from Android version); `5.0.0` (HarmonyOS Next, extracted directly) |
+| OpenHarmony | `OpenHarmony` | `4.1`, `3.2`... |
 | Chrome OS | `Chrome OS` | — |
 | Tizen | `Tizen` | `6.0`, `5.5`... (Samsung Smart TV / wearables) |
 | KaiOS | `KaiOS` | `2.5`, `3.0`... (feature phones in developing markets) |
@@ -100,6 +101,19 @@ WeChat Mini Programs are detected separately via `isWechatMiniapp()` (relies on 
 | MeeGo | `MeeGo` | — |
 | Symbian | `Symbian` | — |
 | WebOS | `WebOS` | — |
+
+::: info HarmonyOS version mapping
+HarmonyOS 2/3/4 is based on the Android compatibility layer. The UA contains an `Android` version token that is mapped to the HarmonyOS display version:
+
+| Android version | HarmonyOS version |
+| :-- | :-- |
+| 10 | `2` |
+| 11 | `3` |
+| 12 | `3` |
+| 13 | `4` |
+
+HarmonyOS Next (5.0+) UAs do not contain an `Android` token. The version is extracted directly from `HarmonyOS 5.0.0`.
+:::
 
 ::: info Windows NT version mapping
 
@@ -127,9 +141,14 @@ WeChat Mini Programs are detected separately via `isWechatMiniapp()` (relies on 
 | EdgeHTML | `EdgeHTML` | Edge (legacy, < 79) |
 | Presto | `Presto` | Opera (legacy, < 15) |
 | KHTML | `KHTML` | Konqueror |
+| ArkWeb | `ArkWeb` | HarmonyOS Next built-in rendering engine (explicit token only) |
 
 ::: tip Blink upgrade
 Before Chrome 28, the engine was WebKit. When Chrome 28+ is detected, the engine is automatically upgraded to `Blink`.
+:::
+
+::: info ArkWeb
+`ArkWeb` is only returned when the UA string explicitly contains the `ArkWeb` token. HarmonyOS Next UAs without the token are correctly identified as `Blink` (Chromium-based).
 :::
 
 ---
@@ -147,15 +166,24 @@ Before Chrome 28, the engine was WebKit. When Chrome 28+ is detected, the engine
 
 ## CPU Architecture
 
-Rules are evaluated from highest to lowest priority; the first match wins:
+As of v1.1.0, a four-layer priority chain is used. Earlier layers take precedence:
 
-| Architecture | `ArchName` | UA markers |
+| Layer | Signal source | Coverage |
+| :--: | :-- | :-- |
+| 1 | UA Client Hints (`navigator.userAgentData`) | Chrome / Edge — precise |
+| 2 | WebGL renderer string | Resolves Apple Silicon vs Intel Mac |
+| 3 | `navigator.platform` inference | Synchronous; covers iPhone / iPad / Linux aarch64 |
+| 4 | UA string pattern matching | Fallback — same as v1.0 behaviour |
+
+**Output values:**
+
+| Architecture | `ArchName` | Common UA / signal markers |
 | :-- | :-- | :-- |
-| ARM 64-bit | `arm64` | `aarch64`, `arm64`, `ARM64` |
-| ARM 32-bit | `arm` | `ARM` (standalone word) |
-| x86 64-bit | `x86_64` | `x86_64`, `Win64`, `WOW64`, `x64;`, `amd64` |
-| x86 32-bit | `x86` | `i386`, `i686`, `x86;` |
-| Unknown | `unknown` | No match |
+| ARM 64-bit | `arm64` | Client Hints `arm/64`; WebGL `Apple M1/M2/A15`; platform `iPhone/iPad`; UA `aarch64`, `arm64` |
+| ARM 32-bit | `arm` | Client Hints `arm/32`; platform `arm`; UA `ARM` |
+| x86 64-bit | `x86_64` | Client Hints `x86/64`; WebGL `Intel/AMD/NVIDIA`; platform `Win64`; UA `x86_64`, `WOW64` |
+| x86 32-bit | `x86` | Client Hints `x86/32`; platform `Win32`; UA `i686` |
+| Unknown | `unknown` | No match in any layer |
 
 ---
 
@@ -226,3 +254,42 @@ The following UA markers cause `isHeadless` to return `true`:
 ::: warning Note
 Cypress and WebdriverIO do not modify the UA by default and cannot be detected at the UA level. Modern stealth libraries (e.g. puppeteer-stealth) can bypass all of the above markers — this detection only covers common unmodified setups.
 :::
+
+---
+
+## Runtime Browser Compatibility
+
+This section describes which browsers can **run** `ua-browser` itself — separate from which browsers it can **detect**.
+
+### Core functions
+
+`parseUA()`, `detectBrowser()`, `detectOs()` and all other synchronous detection functions are **pure regex operations** with no browser API dependencies. They run in any modern JS environment (browser, Node.js, Deno, SSR).
+
+### Build output JS syntax
+
+| Feature | Source | Build output (`target: es2018`) |
+| :-- | :--: | :-- |
+| Optional chaining `?.` | ✓ | Transpiled to `(x == null ? void 0 : x.y)` |
+| Nullish coalescing `??` | ✓ | Transpiled to equivalent ES5 form |
+| `async / await` | ✓ | Kept as-is (ES2017, within es2018 target) |
+
+**Minimum syntax compatibility:** Chrome 63 / Safari 12 / Firefox 55 / Edge 79 (Chromium)
+
+### `getEnvContext()` API compatibility
+
+| API | Chrome | Safari | Firefox | Edge | Notes |
+| :-- | :--: | :--: | :--: | :--: | :-- |
+| `canvas` + `measureText` | 9+ | 3.1+ | 3.5+ | 12+ | Font probes for OS confirmation |
+| WebGL renderer | 9+ | 8+ | 4+ | 12+ | Resolves Apple Silicon vs Intel Mac |
+| `window.matchMedia` | 9+ | 5.1+ | 6+ | 12+ | Pointer / hover capability |
+| `navigator.hardwareConcurrency` | 37+ | 10.1+ | 48+ | 15+ | CPU core count |
+| `navigator.deviceMemory` | 63+ | ✗ | ✗ | 79+ | Memory size, Chrome-only |
+| `userAgentData.getHighEntropyValues` | 90+ | ✗ | ✗ | 90+ | UA Client Hints — most accurate arch source |
+
+::: tip Graceful degradation
+All DOM API calls are wrapped in `try/catch` and `typeof window !== 'undefined'` guards. APIs unavailable in Safari or Firefox are silently skipped. `getEnvContext()` never throws in any environment.
+:::
+
+### `parseHeaders()` compatibility
+
+Pure server-side function with no browser API dependencies. Client Hints headers (`Sec-CH-UA-Arch`, etc.) are only sent automatically by Chrome / Edge 90+. Safari and Firefox do not send them; in those cases `arch` and other fields fall back to UA string matching.

--- a/docs/guide/support-list.md
+++ b/docs/guide/support-list.md
@@ -87,7 +87,8 @@
 | Android | `Android` | `14`、`13`、`12`... |
 | iOS | `iOS` | `17.4`、`16.0`... |
 | macOS | `MacOS` | `10.15.7`... |
-| HarmonyOS | `HarmonyOS` | `2`（基于 Android 版本映射） |
+| HarmonyOS | `HarmonyOS` | `2`、`3`、`4`（Android 版本映射）；`5.0.0`（HarmonyOS Next 直接提取） |
+| OpenHarmony | `OpenHarmony` | `4.1`、`3.2`... |
 | Chrome OS | `Chrome OS` | — |
 | Tizen | `Tizen` | `6.0`、`5.5`...（三星智能电视 / 可穿戴） |
 | KaiOS | `KaiOS` | `2.5`、`3.0`...（发展中国家功能机） |
@@ -100,6 +101,19 @@
 | MeeGo | `MeeGo` | — |
 | Symbian | `Symbian` | — |
 | WebOS | `WebOS` | — |
+
+::: info HarmonyOS 版本映射
+HarmonyOS 2/3/4 基于 Android 兼容层，UA 含 `Android` 字段，版本通过映射表推算：
+
+| Android NT 版本 | HarmonyOS 版本 |
+| :-- | :-- |
+| 10 | `2` |
+| 11 | `3` |
+| 12 | `3` |
+| 13 | `4` |
+
+HarmonyOS Next（5.0+）UA 不含 `Android` 字段，版本从 `HarmonyOS 5.0.0` 直接提取。
+:::
 
 ::: info Windows 版本映射
 UA 中的 `Windows NT` 版本号映射如下：
@@ -128,9 +142,14 @@ UA 中的 `Windows NT` 版本号映射如下：
 | EdgeHTML | `EdgeHTML` | Edge（旧版，< 79） |
 | Presto | `Presto` | Opera（旧版，< 15） |
 | KHTML | `KHTML` | Konqueror |
+| ArkWeb | `ArkWeb` | HarmonyOS Next 内置渲染引擎（部分 UA 显式携带） |
 
 ::: tip Blink 升级
 Chrome 28 之前基于 WebKit。检测到 Chrome 28+ 时，内核自动升级为 `Blink`。
+:::
+
+::: info ArkWeb
+ArkWeb 仅在 HarmonyOS Next 的部分 UA 中显式出现 `ArkWeb` token。无该 token 的 HarmonyOS UA 仍会正确识别为 `Blink`（基于 Chromium 内核）。
 :::
 
 ---
@@ -148,15 +167,24 @@ Chrome 28 之前基于 WebKit。检测到 Chrome 28+ 时，内核自动升级为
 
 ## CPU 架构
 
-检测规则按优先级从高到低，首个匹配项胜出：
+v1.1.0 起采用四层优先级检测链，前层成功则跳过后层：
 
-| 架构 | `ArchName` | UA 特征 |
+| 层级 | 数据来源 | 覆盖场景 |
+| :--: | :-- | :-- |
+| 1 | UA Client Hints（`navigator.userAgentData`） | Chrome / Edge，精确 |
+| 2 | WebGL 渲染器字符串 | 解决 Apple Silicon vs Intel Mac 问题 |
+| 3 | `navigator.platform` 推断 | 同步，覆盖 iPhone / iPad / Linux aarch64 |
+| 4 | UA 字符串模式匹配 | 兜底，与 v1.0 行为一致 |
+
+**输出值：**
+
+| 架构 | `ArchName` | 常见 UA / 信号特征 |
 | :-- | :-- | :-- |
-| ARM 64 位 | `arm64` | `aarch64`、`arm64`、`ARM64` |
-| ARM 32 位 | `arm` | `ARM`（独立单词） |
-| x86 64 位 | `x86_64` | `x86_64`、`Win64`、`WOW64`、`x64;`、`amd64` |
-| x86 32 位 | `x86` | `i386`、`i686`、`x86;` |
-| 未知 | `unknown` | 无匹配 |
+| ARM 64 位 | `arm64` | Client Hints `arm/64`；WebGL `Apple M1/M2/A15`；platform `iPhone/iPad`；UA `aarch64`、`arm64` |
+| ARM 32 位 | `arm` | Client Hints `arm/32`；platform `arm`；UA `ARM` |
+| x86 64 位 | `x86_64` | Client Hints `x86/64`；WebGL `Intel/AMD/NVIDIA`；platform `Win64`；UA `x86_64`、`WOW64` |
+| x86 32 位 | `x86` | Client Hints `x86/32`；platform `Win32`；UA `i686` |
+| 未知 | `unknown` | 以上均无匹配 |
 
 ---
 
@@ -227,3 +255,42 @@ Chrome 28 之前基于 WebKit。检测到 Chrome 28+ 时，内核自动升级为
 ::: warning 注意
 Cypress、WebdriverIO 默认不修改 UA，无法从 UA 层面检测。现代隐身模式（如 puppeteer-stealth）可绕过以上所有标识，本检测仅覆盖未经伪装的常见场景。
 :::
+
+---
+
+## 运行时浏览器兼容性
+
+本节说明 `ua-browser` 自身代码能在哪些浏览器中运行，与「能检测哪些浏览器」是两个独立问题。
+
+### 核心函数
+
+`parseUA()`、`detectBrowser()`、`detectOs()` 等所有同步检测函数为**纯正则运算**，无任何浏览器 API 依赖，可在所有现代 JS 环境（浏览器、Node.js、Deno、SSR）中运行。
+
+### 构建产物 JS 语法
+
+| 特性 | 源码 | 构建产物（`target: es2018`） |
+| :-- | :--: | :-- |
+| 可选链 `?.` | ✓ | 转译为 `(x == null ? void 0 : x.y)` |
+| 空值合并 `??` | ✓ | 转译为等价 ES5 写法 |
+| `async / await` | ✓ | 保留（ES2017，在 es2018 目标范围内）|
+
+**最低语法兼容版本：** Chrome 63 / Safari 12 / Firefox 55 / Edge 79（Chromium）
+
+### `getEnvContext()` 各 API 兼容性
+
+| API | Chrome | Safari | Firefox | Edge | 说明 |
+| :-- | :--: | :--: | :--: | :--: | :-- |
+| `canvas` + `measureText` | 9+ | 3.1+ | 3.5+ | 12+ | 字体探针，用于确认 OS 检测结果 |
+| `WebGL` 渲染器 | 9+ | 8+ | 4+ | 12+ | 解决 Apple Silicon vs Intel Mac |
+| `window.matchMedia` | 9+ | 5.1+ | 6+ | 12+ | 触屏 / 悬停能力检测 |
+| `navigator.hardwareConcurrency` | 37+ | 10.1+ | 48+ | 15+ | CPU 核心数 |
+| `navigator.deviceMemory` | 63+ | ✗ | ✗ | 79+ | 内存大小，Chrome 独有 |
+| `userAgentData.getHighEntropyValues` | 90+ | ✗ | ✗ | 90+ | UA Client Hints，最精确的 arch 来源 |
+
+::: tip 降级策略
+所有 DOM API 调用均包裹在 `try/catch` 与 `typeof window !== 'undefined'` 判断中。Safari / Firefox 不支持的 API 会静默跳过，`getEnvContext()` 在任何环境下都不会抛出异常。
+:::
+
+### `parseHeaders()` 兼容性
+
+纯服务端函数，无浏览器 API 依赖。Client Hints 头部（`Sec-CH-UA-Arch` 等）仅 Chrome / Edge 90+ 会自动发送；Safari / Firefox 不发送，此时 `arch` 等字段退回到 UA 字符串匹配结果。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ua-browser",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "dist"
   ],
   "sideEffects": false,
+  "browserslist": [
+    "chrome >= 63",
+    "safari >= 12",
+    "firefox >= 55",
+    "edge >= 79"
+  ],
   "scripts": {
     "release": "pnpm build && changeset publish",
     "build": "tsup",

--- a/src/constants/engines.ts
+++ b/src/constants/engines.ts
@@ -8,5 +8,8 @@ export const ENGINE_DEFS: readonly EngineDef[] = [
   { name: 'Trident', detect: /(Trident|NET CLR)/ },
   { name: 'Presto',  detect: /Presto/ },
   { name: 'Gecko',   detect: /Gecko\// },
-  { name: 'WebKit',  detect: /AppleWebKit/ }
+  { name: 'WebKit',  detect: /AppleWebKit/ },
+  // ArkWeb is HarmonyOS Next's rendering engine; only present in UAs that explicitly contain the
+  // token. It must come last so it overrides the WebKit entry that also matches those UAs.
+  { name: 'ArkWeb',  detect: /ArkWeb/ },
 ] as const

--- a/src/constants/os.ts
+++ b/src/constants/os.ts
@@ -3,8 +3,8 @@ import type { OsName } from '../types.js'
 export interface OsDef {
   name: OsName
   detect: RegExp
-  /** Capture-group regex for OS version extraction. null = no version. */
-  versionPattern: RegExp | null
+  /** Capture-group regex(es) for OS version extraction. Tried in order; null = no version. */
+  versionPattern: RegExp | RegExp[] | null
   /** Lookup table: raw version token → display version. */
   versionLookup?: Record<string, string>
 }
@@ -28,9 +28,13 @@ export const OS_DEFS: readonly OsDef[] = [
   { name: 'MacOS',          detect: /Macintosh/,                      versionPattern: /Mac OS X -?([\d_.]+)/ },
   { name: 'Android',        detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
   // HarmonyOS must come after Android: HarmonyOS UAs include "Android", so Android matches
-  // first, then HarmonyOS overrides it.
-  { name: 'HarmonyOS',      detect: /HarmonyOS/,                      versionPattern: /Android ([\d.]+)[;)]/,
-    versionLookup: { '10': '2' } },
+  // first, then HarmonyOS overrides it. versionPattern tries direct extraction first (5.0+
+  // pure HarmonyOS UAs don't have Android token), then falls back to Android version + lookup.
+  { name: 'HarmonyOS',      detect: /HarmonyOS/,
+    versionPattern: [/HarmonyOS[\s/]([\d.]+)/, /Android ([\d.]+)[;)]/],
+    versionLookup: { '10': '2', '11': '3', '12': '3', '13': '4' } },
+  // OpenHarmony (open-source base) must come after HarmonyOS to override any earlier match.
+  { name: 'OpenHarmony',    detect: /OpenHarmony/,                    versionPattern: /OpenHarmony[\s/]([\d.]+)/ },
   { name: 'KaiOS',          detect: /KAIOS/,                          versionPattern: /KAIOS\/([\d.]+)/ },
   // Windows must come before Windows Phone: Windows Phone UAs contain "Windows", so Windows
   // matches first, then Windows Phone overrides it.

--- a/src/detectors/arch.ts
+++ b/src/detectors/arch.ts
@@ -1,14 +1,53 @@
 import { ARCH_DEFS, type ArchName } from '../constants/arch.js'
+import type { EnvContext } from '../utils/env-context.js'
 
 /**
- * Detect the CPU architecture from a user agent string.
- * Returns 'unknown' when the UA provides no architecture hints.
+ * Detect the CPU architecture using a 4-layer priority chain.
+ *
+ * Layer 1 (highest): UA Client Hints — precise, Chrome/Edge only
+ * Layer 2: WebGL renderer string — resolves Apple Silicon vs Intel Mac
+ * Layer 3: navigator.platform — synchronous, covers iPhone/iPad/Linux aarch64
+ * Layer 4 (lowest): UA string pattern matching — existing behaviour, fallback
  */
-export function detectArch(ua: string): ArchName {
+export function detectArch(ua: string, ctx?: EnvContext): ArchName {
+  // Layer 1: UA Client Hints (most reliable when available)
+  if (ctx?.highEntropyData) {
+    const { architecture, bitness } = ctx.highEntropyData
+    if (architecture === 'arm') {
+      return bitness === '64' ? 'arm64' : 'arm'
+    }
+    if (architecture === 'x86') {
+      return bitness === '64' ? 'x86_64' : 'x86'
+    }
+  }
+
+  // Layer 2: WebGL renderer — disambiguates Apple Silicon vs Intel Mac
+  const renderer = ctx?.webglRenderer
+  if (renderer) {
+    if (/Apple\s+(M\d|A\d{1,2}[A-Z]?)\b/i.test(renderer) || /APPLE M\d/i.test(renderer)) {
+      return 'arm64'
+    }
+    if (/\b(Intel|AMD|NVIDIA|Radeon)\b/i.test(renderer)) {
+      return 'x86_64'
+    }
+  }
+
+  // Layer 3: navigator.platform — synchronous, broad coverage
+  const platform = ctx?.platform
+  if (platform) {
+    if (/iPhone|iPad|iPod/.test(platform)) return 'arm64'
+    if (/arm64|aarch64/i.test(platform)) return 'arm64'
+    if (/arm/i.test(platform)) return 'arm'
+    if (/Win64|WOW64|x86_64/i.test(platform)) return 'x86_64'
+    if (/Win32|i686/i.test(platform)) return 'x86'
+  }
+
+  // Layer 4: UA string pattern matching (original behaviour)
   for (const def of ARCH_DEFS) {
     if (def.detect.test(ua)) {
       return def.name
     }
   }
+
   return 'unknown'
 }

--- a/src/detectors/os.ts
+++ b/src/detectors/os.ts
@@ -1,6 +1,6 @@
 import type { OsName } from '../types.js'
 import { OS_DEFS } from '../constants/os.js'
-import { extractVersion } from '../utils/extract.js'
+import { extractVersion, extractVersionFromPatterns } from '../utils/extract.js'
 
 export interface OsResult {
   os: OsName
@@ -29,7 +29,9 @@ export function detectOs(ua: string, windowsVersion?: string | null): OsResult {
   let osVersion = 'unknown'
 
   if (matchedDef.versionPattern) {
-    const raw = extractVersion(ua, matchedDef.versionPattern)
+    const raw = Array.isArray(matchedDef.versionPattern)
+      ? extractVersionFromPatterns(ua, matchedDef.versionPattern)
+      : extractVersion(ua, matchedDef.versionPattern)
 
     if (raw !== null) {
       // Normalise iOS underscore-separated version: "17_4_1" → "17.4.1"
@@ -47,6 +49,9 @@ export function detectOs(ua: string, windowsVersion?: string | null): OsResult {
           // For unknown Windows NT versions, fall back to the integer part
           const n = parseInt(normalised, 10)
           osVersion = isNaN(n) ? 'unknown' : n.toString()
+        } else {
+          // For other OS types (e.g. HarmonyOS Next), use raw version directly
+          osVersion = normalised
         }
       } else {
         osVersion = normalised

--- a/src/detectors/webview.ts
+++ b/src/detectors/webview.ts
@@ -1,0 +1,12 @@
+/**
+ * Detect whether the UA is running inside a native app webview.
+ *
+ * - Android WebView: always includes "; wv" in the UA string.
+ * - iOS WKWebView: iOS UA (contains "like Mac OS X") without Version/ and without Safari/
+ *   CriOS, FxiOS, and DuckDuckGo all include "Safari/" so they are not affected.
+ */
+export function isWebview(ua: string): boolean {
+  if (/; wv/.test(ua)) return true
+  if (/like Mac OS X/.test(ua) && !/Version\//.test(ua) && !/Safari\//.test(ua)) return true
+  return false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import pkg from '../package.json' with { type: 'json' }
 const { version: VERSION } = pkg
 import { parseUA } from './parse.js'
 import { getNavContext, getLanguage } from './utils/navigator.js'
+import { isWebview } from './detectors/webview.js'
 import type { EnvOption } from './types.js'
 
 // ── Named exports (tree-shakeable) ──────────────────────────────────────────
@@ -9,13 +10,14 @@ export type { EnvOption, BrowserName, OsName, EngineName, DeviceName, ArchName, 
 export { parseUA } from './parse.js'
 export { getLanguage, getNavContext } from './utils/navigator.js'
 export { getWindowsVersion } from './utils/windows-version.js'
+export { getEnvContext } from './utils/env-context.js'
+export type { EnvContext, UAHighEntropyValues } from './utils/env-context.js'
 export { detectBot } from './detectors/bot.js'
 export { detectArch } from './detectors/arch.js'
 export { detectHeadless } from './detectors/headless.js'
+export { isWebview } from './detectors/webview.js'
+export { parseHeaders, ACCEPT_CH } from './parse-headers.js'
 export { VERSION }
-
-/** Check whether a UA string indicates an Android webview environment. */
-export const isWebview = (ua: string): boolean => /; wv/.test(ua)
 
 /** Check whether the current context is a WeChat mini-program. */
 export const isWechatMiniapp = (): boolean => {

--- a/src/parse-headers.ts
+++ b/src/parse-headers.ts
@@ -1,0 +1,84 @@
+import type { EnvOption } from './types.js'
+import type { UAHighEntropyValues, EnvContext } from './utils/env-context.js'
+import { parseUA } from './parse.js'
+
+/**
+ * The Accept-CH value to send in server responses.
+ * After the browser sees this header it will include the corresponding
+ * Sec-CH-UA-* headers on subsequent same-origin requests.
+ */
+export const ACCEPT_CH = [
+  'Sec-CH-UA-Arch',
+  'Sec-CH-UA-Bitness',
+  'Sec-CH-UA-Platform-Version',
+  'Sec-CH-UA-Model',
+  'Sec-CH-UA-Full-Version-List',
+].join(', ')
+
+/** Strip the surrounding double-quotes that browsers add to structured header values. */
+function unquote(value: string | undefined): string | undefined {
+  if (value == null) return undefined
+  return value.replace(/^"|"$/g, '').trim() || undefined
+}
+
+function deriveWindowsVersion(platformVersion: string | undefined): string | null {
+  if (!platformVersion) return null
+  const major = parseInt(platformVersion.split('.')[0] ?? '0', 10)
+  return isNaN(major) ? null : major >= 13 ? '11' : '10'
+}
+
+/**
+ * Parse a browser request's HTTP headers into an EnvOption.
+ *
+ * Reads the standard `user-agent` header plus any `Sec-CH-UA-*` Client Hints
+ * headers the browser sent after receiving an `Accept-CH` response header.
+ *
+ * Header names are matched case-insensitively, as required by HTTP/1.1 and HTTP/2.
+ *
+ * @example
+ * // Express / Node.js
+ * res.setHeader('Accept-CH', ACCEPT_CH)
+ * const result = parseHeaders(req.headers)
+ */
+export function parseHeaders(headers: Record<string, string | string[] | undefined>): EnvOption {
+  // Normalise all header keys to lowercase for case-insensitive lookup (HTTP spec)
+  const normalised: Record<string, string | string[] | undefined> = {}
+  for (const key of Object.keys(headers)) {
+    normalised[key.toLowerCase()] = headers[key]
+  }
+  const get = (name: string): string | undefined => {
+    const v = normalised[name.toLowerCase()]
+    return Array.isArray(v) ? v[0] : v
+  }
+
+  const ua = get('user-agent') ?? ''
+
+  const architecture = unquote(get('sec-ch-ua-arch'))
+  const bitness = unquote(get('sec-ch-ua-bitness'))
+  const model = unquote(get('sec-ch-ua-model'))
+  const platformVersion = unquote(get('sec-ch-ua-platform-version'))
+  const platform = unquote(get('sec-ch-ua-platform')) ?? ''
+
+  const highEntropyData: UAHighEntropyValues = {}
+  if (architecture !== undefined) highEntropyData.architecture = architecture
+  if (bitness !== undefined) highEntropyData.bitness = bitness
+  if (model !== undefined) highEntropyData.model = model
+  if (platformVersion !== undefined) highEntropyData.platformVersion = platformVersion
+
+  const isMobile = get('sec-ch-ua-mobile') === '?1'
+
+  const windowsVersion = platform === 'Windows'
+    ? deriveWindowsVersion(platformVersion)
+    : null
+
+  const ctx: EnvContext = {
+    userAgent: ua,
+    platform,
+    language: '',
+    maxTouchPoints: isMobile ? 1 : 0,
+    highEntropyData: Object.keys(highEntropyData).length > 0 ? highEntropyData : undefined,
+    windowsVersion,
+  }
+
+  return parseUA(ua, { ctx })
+}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,13 +6,17 @@ import { detectDevice } from './detectors/device.js'
 import { detectBot } from './detectors/bot.js'
 import { detectArch } from './detectors/arch.js'
 import { detectHeadless } from './detectors/headless.js'
+import { isWebview } from './detectors/webview.js'
 import { getMimeType, getLanguage, type NavContext } from './utils/navigator.js'
+import type { EnvContext } from './utils/env-context.js'
 
 export interface ParseOptions {
   /** Nav context to use for language, platform, MIME-type checks, and device detection. */
   nav?: NavContext
   /** Pre-resolved Windows version string (from getWindowsVersion()). Pass to avoid async races. */
   windowsVersion?: string | null
+  /** Full env context from getEnvContext() — supersedes nav and windowsVersion when provided. */
+  ctx?: EnvContext
 }
 
 /**
@@ -22,13 +26,15 @@ export interface ParseOptions {
  * supplied through `options.nav`; omit it for Node.js / testing contexts.
  */
 export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
-  const { nav, windowsVersion } = options
+  const effectiveNav: NavContext | undefined = options.ctx ?? options.nav
+  const effectiveWindowsVersion = options.ctx?.windowsVersion ?? options.windowsVersion
 
   const { browser: rawBrowser, version: rawVersion } = detectBrowser(ua)
-  const { os, osVersion: rawOsVersion } = detectOs(ua, windowsVersion)
+  const { os, osVersion: rawOsVersion } = detectOs(ua, effectiveWindowsVersion)
   let osVersion = rawOsVersion
-  const device = detectDevice(ua, nav)
-  const arch = detectArch(ua)
+  const device = detectDevice(ua, effectiveNav)
+  const arch = detectArch(ua, options.ctx)
+  const nav = effectiveNav
   const { isBot, botName } = detectBot(ua)
   const isHeadless = detectHeadless(ua)
   const language = nav ? getLanguage(nav) : 'unknown'
@@ -144,7 +150,7 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
     osVersion,
     device,
     arch,
-    isWebview: /; wv/.test(ua),
+    isWebview: isWebview(ua),
     isHeadless,
     isBot,
     botName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type EngineName =
   | 'KHTML'
   | 'Blink'
   | 'EdgeHTML'
+  | 'ArkWeb'
   | 'unknown'
 
 export type BrowserName =
@@ -71,6 +72,7 @@ export type OsName =
   | 'MacOS'
   | 'Android'
   | 'HarmonyOS'
+  | 'OpenHarmony'
   | 'Ubuntu'
   | 'FreeBSD'
   | 'Debian'
@@ -152,6 +154,7 @@ declare global {
 
   interface Navigator {
     browserLanguage?: string
+    deviceMemory?: number
     userAgentData?: {
       platform: string
       getHighEntropyValues(hints: string[]): Promise<Record<string, string>>

--- a/src/utils/env-context.ts
+++ b/src/utils/env-context.ts
@@ -1,0 +1,141 @@
+import type { NavContext } from './navigator.js'
+import { getNavContext } from './navigator.js'
+
+export interface UAHighEntropyValues {
+  architecture?: string
+  bitness?: string
+  model?: string
+  platformVersion?: string
+  fullVersionList?: Array<{ brand: string; version: string }>
+}
+
+export interface EnvContext extends NavContext {
+  webglRenderer?: string
+  webglVendor?: string
+  hardwareConcurrency?: number
+  deviceMemory?: number
+  devicePixelRatio?: number
+  pointerType?: 'coarse' | 'fine' | 'none'
+  hoverCapability?: boolean
+  fontProbes?: Record<string, boolean>
+  highEntropyData?: UAHighEntropyValues
+  windowsVersion?: string | null
+}
+
+// OS-specific system fonts used to cross-confirm UA-based OS detection.
+// Only ~5 fonts; each measureText() call is < 1ms total overhead < 5ms.
+const OS_FONTS = [
+  '.AppleSystemUIFont',
+  'Segoe UI',
+  'Noto Color Emoji',
+  'Ubuntu',
+  'HarmonyOS Sans',
+]
+
+function probeFonts(): Record<string, boolean> {
+  try {
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return {}
+    const TEST = 'mmmmmmmmmmlli'
+    ctx.font = '72px monospace'
+    const baseline = ctx.measureText(TEST).width
+    const result: Record<string, boolean> = {}
+    for (const font of OS_FONTS) {
+      ctx.font = `72px '${font}', monospace`
+      result[font] = ctx.measureText(TEST).width !== baseline
+    }
+    return result
+  } catch {
+    return {}
+  }
+}
+
+function getWebGLInfo(): { renderer?: string; vendor?: string } {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = (canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl')) as WebGLRenderingContext | null
+    if (!gl) return {}
+    const ext = gl.getExtension('WEBGL_debug_renderer_info')
+    if (!ext) return {}
+    return {
+      renderer: gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) as string,
+      vendor: gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) as string,
+    }
+  } catch {
+    return {}
+  }
+}
+
+function getPointerType(): 'coarse' | 'fine' | 'none' | undefined {
+  try {
+    if (window.matchMedia('(pointer: coarse)').matches) return 'coarse'
+    if (window.matchMedia('(pointer: fine)').matches) return 'fine'
+    if (window.matchMedia('(pointer: none)').matches) return 'none'
+  } catch {
+    // matchMedia unavailable
+  }
+  return undefined
+}
+
+function getHoverCapability(): boolean | undefined {
+  try {
+    return window.matchMedia('(hover: hover)').matches
+  } catch {
+    return undefined
+  }
+}
+
+function deriveWindowsVersion(platformVersion: string | undefined): string | null {
+  if (!platformVersion) return null
+  const major = parseInt(platformVersion.split('.')[0] ?? '0', 10)
+  return isNaN(major) ? null : major >= 13 ? '11' : '10'
+}
+
+/**
+ * Collect all available browser signals into a single EnvContext.
+ * Safe to call in Node.js/SSR — missing APIs degrade gracefully.
+ * Await this once at app start, then pass the result to parseUA() as `options.ctx`.
+ */
+export async function getEnvContext(): Promise<EnvContext> {
+  const base = getNavContext()
+
+  const ctx: EnvContext = { ...base }
+
+  if (typeof navigator !== 'undefined') {
+    ctx.hardwareConcurrency = navigator.hardwareConcurrency
+    ctx.deviceMemory = navigator.deviceMemory
+  }
+
+  if (typeof window !== 'undefined') {
+    ctx.devicePixelRatio = window.devicePixelRatio
+    ctx.pointerType = getPointerType()
+    ctx.hoverCapability = getHoverCapability()
+    ctx.fontProbes = probeFonts()
+    const { renderer, vendor } = getWebGLInfo()
+    if (renderer !== undefined) ctx.webglRenderer = renderer
+    if (vendor !== undefined) ctx.webglVendor = vendor
+  }
+
+  if (base.userAgentData) {
+    try {
+      const data = await base.userAgentData.getHighEntropyValues([
+        'architecture', 'bitness', 'model', 'platformVersion', 'fullVersionList',
+      ])
+      ctx.highEntropyData = {
+        architecture: data['architecture'],
+        bitness: data['bitness'],
+        model: data['model'],
+        platformVersion: data['platformVersion'],
+        fullVersionList: data['fullVersionList'] as unknown as Array<{ brand: string; version: string }>,
+      }
+      if (base.userAgentData.platform === 'Windows') {
+        ctx.windowsVersion = deriveWindowsVersion(data['platformVersion'])
+      }
+    } catch {
+      // High entropy values unavailable (non-Chrome, permission denied, etc.)
+    }
+  }
+
+  return ctx
+}

--- a/test/arch.test.ts
+++ b/test/arch.test.ts
@@ -40,4 +40,49 @@ describe('detectArch', () => {
   it('empty UA → unknown', () => {
     expect(detectArch('')).toBe('unknown')
   })
+
+  it('Layer 1: Client Hints arm/64 → arm64', () => {
+    const ctx = { userAgent: UA.safari.ios, platform: '', language: '', maxTouchPoints: 5,
+      highEntropyData: { architecture: 'arm', bitness: '64' } }
+    expect(detectArch(UA.safari.ios, ctx)).toBe('arm64')
+  })
+
+  it('Layer 1: Client Hints arm/32 → arm', () => {
+    const ctx = { userAgent: '', platform: '', language: '', maxTouchPoints: 0,
+      highEntropyData: { architecture: 'arm', bitness: '32' } }
+    expect(detectArch('', ctx)).toBe('arm')
+  })
+
+  it('Layer 1: Client Hints x86/64 → x86_64', () => {
+    const ctx = { userAgent: '', platform: '', language: '', maxTouchPoints: 0,
+      highEntropyData: { architecture: 'x86', bitness: '64' } }
+    expect(detectArch('', ctx)).toBe('x86_64')
+  })
+
+  it('Layer 2: WebGL Apple M2 renderer → arm64', () => {
+    const ctx = { userAgent: '', platform: '', language: '', maxTouchPoints: 0,
+      webglRenderer: 'Apple M2' }
+    expect(detectArch('', ctx)).toBe('arm64')
+  })
+
+  it('Layer 2: WebGL Intel GPU renderer → x86_64', () => {
+    const ctx = { userAgent: '', platform: '', language: '', maxTouchPoints: 0,
+      webglRenderer: 'Intel Iris Pro OpenGL Engine' }
+    expect(detectArch('', ctx)).toBe('x86_64')
+  })
+
+  it('Layer 3: iPhone platform → arm64', () => {
+    const ctx = { userAgent: UA.safari.ios, platform: 'iPhone', language: '', maxTouchPoints: 5 }
+    expect(detectArch(UA.safari.ios, ctx)).toBe('arm64')
+  })
+
+  it('Layer 3: Win32 platform → x86', () => {
+    const ctx = { userAgent: '', platform: 'Win32', language: '', maxTouchPoints: 0 }
+    expect(detectArch('', ctx)).toBe('x86')
+  })
+
+  it('Layer 4 (UA fallback) used when ctx has no useful signals', () => {
+    const ctx = { userAgent: UA.chrome.windows, platform: '', language: '', maxTouchPoints: 0 }
+    expect(detectArch(UA.chrome.windows, ctx)).toBe('x86_64')  // Win64 in UA
+  })
 })

--- a/test/compat.test.ts
+++ b/test/compat.test.ts
@@ -4,10 +4,14 @@ import uaBrowser, {
   isWebview,
   isWechatMiniapp,
   getLanguage,
+  getNavContext,
   getWindowsVersion,
+  getEnvContext,
   detectBot,
   detectArch,
   detectHeadless,
+  parseHeaders,
+  ACCEPT_CH,
   VERSION
 } from '../src/index.js'
 
@@ -87,5 +91,32 @@ describe('API surface', () => {
   it('VERSION matches package.json version', async () => {
     const pkg = await import('../package.json', { assert: { type: 'json' } })
     expect(VERSION).toBe(pkg.default.version)
+  })
+
+  it('named export getNavContext is a function', () => {
+    expect(typeof getNavContext).toBe('function')
+  })
+
+  it('named export getEnvContext is a function', () => {
+    expect(typeof getEnvContext).toBe('function')
+  })
+
+  it('named export parseHeaders is a function', () => {
+    expect(typeof parseHeaders).toBe('function')
+  })
+
+  it('named export ACCEPT_CH is a string', () => {
+    expect(typeof ACCEPT_CH).toBe('string')
+    expect(ACCEPT_CH.length).toBeGreaterThan(0)
+  })
+
+  it('isWebview detects iOS WKWebView (no Version/, no Safari/)', () => {
+    const iosWKWebView = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+    expect(isWebview(iosWKWebView)).toBe(true)
+  })
+
+  it('isWebview does not flag CriOS as webview (has Safari/)', () => {
+    const crios = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.0.0 Mobile/15E148 Safari/604.1'
+    expect(isWebview(crios)).toBe(false)
   })
 })

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -46,4 +46,12 @@ describe('detectEngine', () => {
     const yandexUA = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/24.1.0 Safari/537.36'
     expect(detectEngine(yandexUA, 'Yandex', '24.1.0')).toBe('Blink')
   })
+
+  it('HarmonyOS ArkWeb UA → ArkWeb (not WebKit)', () => {
+    expect(detectEngine(UA.harmonyOs.arkWeb, 'Chrome', '124.0.0.0')).toBe('ArkWeb')
+  })
+
+  it('HarmonyOS Next without ArkWeb token → Blink', () => {
+    expect(detectEngine(UA.harmonyOs.next, 'Chrome', '124.0.0.0')).toBe('Blink')
+  })
 })

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -82,7 +82,19 @@ export const UA = {
   },
   // OS-specific
   webview: {
-    android: 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36; wv)'
+    android: 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36; wv)',
+    iosWKWebView: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+  },
+  // HarmonyOS / OpenHarmony
+  harmonyOs: {
+    legacy: 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ANA-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 HuaweiBrowser/11.0.8.301 Mobile Safari/537.36',
+    android11: 'Mozilla/5.0 (Linux; Android 11; NOH-AN00; HarmonyOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.48 Mobile Safari/537.36',
+    android13: 'Mozilla/5.0 (Linux; Android 13; HarmonyOS; HUAWEI Mate60Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36',
+    next: 'Mozilla/5.0 (Linux; HarmonyOS 5.0.0; HUAWEI GT5 Pro Build/HUAWEIAGT5Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+    arkWeb: 'Mozilla/5.0 (Linux; HarmonyOS 5.0; Huawei ArkWeb/4.1.6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+  },
+  openHarmony: {
+    standard: 'Mozilla/5.0 (Linux; OpenHarmony 4.1; HONOR X8b Build/HONORX8b) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36',
   },
   // Empty / edge cases
   empty: '',

--- a/test/os.test.ts
+++ b/test/os.test.ts
@@ -79,11 +79,39 @@ describe('detectOs', () => {
     expect(r.osVersion).toBe('10.0')
   })
 
-  it('HarmonyOS → HarmonyOS (not misidentified as Android)', () => {
-    const ua = 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ANA-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 HuaweiBrowser/11.0.8.301 Mobile Safari/537.36'
-    const r = detectOs(ua)
+  it('HarmonyOS legacy (Android 10) → HarmonyOS 2', () => {
+    const r = detectOs(UA.harmonyOs.legacy)
     expect(r.os).toBe('HarmonyOS')
     expect(r.osVersion).toBe('2')
+  })
+
+  it('HarmonyOS with Android 11 base → HarmonyOS 3', () => {
+    const r = detectOs(UA.harmonyOs.android11)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('3')
+  })
+
+  it('HarmonyOS with Android 13 base → HarmonyOS 4', () => {
+    const r = detectOs(UA.harmonyOs.android13)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('4')
+  })
+
+  it('HarmonyOS Next (5.0+, no Android token) → HarmonyOS 5.0.0', () => {
+    const r = detectOs(UA.harmonyOs.next)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('5.0.0')
+  })
+
+  it('HarmonyOS ArkWeb UA → HarmonyOS (not misidentified as Android)', () => {
+    const r = detectOs(UA.harmonyOs.arkWeb)
+    expect(r.os).toBe('HarmonyOS')
+  })
+
+  it('OpenHarmony → OpenHarmony with version', () => {
+    const r = detectOs(UA.openHarmony.standard)
+    expect(r.os).toBe('OpenHarmony')
+    expect(r.osVersion).toBe('4.1')
   })
 
   it('returns unknown for empty UA', () => {

--- a/test/parse-headers.test.ts
+++ b/test/parse-headers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { parseHeaders, ACCEPT_CH } from '../src/parse-headers.js'
+import { UA } from './fixtures/user-agents.js'
+
+describe('ACCEPT_CH', () => {
+  it('contains all required Sec-CH-UA headers', () => {
+    expect(ACCEPT_CH).toContain('Sec-CH-UA-Arch')
+    expect(ACCEPT_CH).toContain('Sec-CH-UA-Bitness')
+    expect(ACCEPT_CH).toContain('Sec-CH-UA-Platform-Version')
+    expect(ACCEPT_CH).toContain('Sec-CH-UA-Model')
+    expect(ACCEPT_CH).toContain('Sec-CH-UA-Full-Version-List')
+  })
+})
+
+describe('parseHeaders', () => {
+  it('parses user-agent header', () => {
+    const r = parseHeaders({ 'user-agent': UA.chrome.windows })
+    expect(r.browser).toBe('Chrome')
+    expect(r.os).toBe('Windows')
+    expect(r.engine).toBe('Blink')
+  })
+
+  it('header names are case-insensitive', () => {
+    const r = parseHeaders({ 'User-Agent': UA.chrome.windows })
+    expect(r.browser).toBe('Chrome')
+  })
+
+  it('arch from Sec-CH-UA-Arch + Sec-CH-UA-Bitness (arm/64 → arm64)', () => {
+    const r = parseHeaders({
+      'user-agent': UA.safari.ios,
+      'sec-ch-ua-arch': '"arm"',
+      'sec-ch-ua-bitness': '"64"',
+    })
+    expect(r.arch).toBe('arm64')
+  })
+
+  it('arch from Sec-CH-UA-Arch + Sec-CH-UA-Bitness (x86/64 → x86_64)', () => {
+    const r = parseHeaders({
+      'user-agent': UA.chrome.windows,
+      'sec-ch-ua-arch': '"x86"',
+      'sec-ch-ua-bitness': '"64"',
+    })
+    expect(r.arch).toBe('x86_64')
+  })
+
+  it('Windows 11 from Sec-CH-UA-Platform-Version >= 13', () => {
+    const r = parseHeaders({
+      'user-agent': UA.chrome.windows,
+      'sec-ch-ua-platform': '"Windows"',
+      'sec-ch-ua-platform-version': '"13.0.0"',
+    })
+    expect(r.os).toBe('Windows')
+    expect(r.osVersion).toBe('11')
+  })
+
+  it('Windows 10 from Sec-CH-UA-Platform-Version < 13', () => {
+    const r = parseHeaders({
+      'user-agent': UA.chrome.windows,
+      'sec-ch-ua-platform': '"Windows"',
+      'sec-ch-ua-platform-version': '"10.0.0"',
+    })
+    expect(r.os).toBe('Windows')
+    expect(r.osVersion).toBe('10')
+  })
+
+  it('mobile flag from sec-ch-ua-mobile: ?1', () => {
+    const r = parseHeaders({
+      'user-agent': UA.chrome.android,
+      'sec-ch-ua-mobile': '?1',
+    })
+    expect(r.browser).toBe('Chrome')
+    expect(r.os).toBe('Android')
+  })
+
+  it('empty headers returns unknown results', () => {
+    const r = parseHeaders({})
+    expect(r.browser).toBe('unknown')
+    expect(r.os).toBe('unknown')
+  })
+
+  it('strips surrounding quotes from header values', () => {
+    const r = parseHeaders({
+      'user-agent': UA.chrome.windows,
+      'sec-ch-ua-arch': '"x86"',
+      'sec-ch-ua-bitness': '"64"',
+    })
+    expect(r.arch).toBe('x86_64')
+  })
+})

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -116,8 +116,20 @@ describe('parseUA — full pipeline', () => {
 })
 
 describe('parseUA — webview detection', () => {
-  it('; wv in UA → isWebview: true', () => {
+  it('Android ; wv → isWebview: true', () => {
     expect(parseUA(UA.webview.android).isWebview).toBe(true)
+  })
+
+  it('iOS WKWebView (no Version/, no Safari/) → isWebview: true', () => {
+    expect(parseUA(UA.webview.iosWKWebView).isWebview).toBe(true)
+  })
+
+  it('iOS Safari (has Version/ and Safari/) → isWebview: false', () => {
+    expect(parseUA(UA.safari.ios).isWebview).toBe(false)
+  })
+
+  it('CriOS on iOS (has Safari/) → isWebview: false', () => {
+    expect(parseUA(UA.chrome.crios).isWebview).toBe(false)
   })
 
   it('no ; wv → isWebview: false', () => {
@@ -130,6 +142,28 @@ describe('parseUA — windowsVersion override', () => {
     const r = parseUA(UA.chrome.windows, { windowsVersion: '11' })
     expect(r.os).toBe('Windows')
     expect(r.osVersion).toBe('11')
+  })
+})
+
+describe('parseUA — ctx option', () => {
+  it('ctx.windowsVersion supersedes options.windowsVersion', () => {
+    const ctx = { userAgent: UA.chrome.windows, platform: 'Win32', language: 'en-US',
+      maxTouchPoints: 0, windowsVersion: '11' }
+    const r = parseUA(UA.chrome.windows, { ctx, windowsVersion: '10' })
+    expect(r.osVersion).toBe('11')
+  })
+
+  it('ctx.highEntropyData.architecture used for arch detection', () => {
+    const ctx = { userAgent: UA.safari.ios, platform: 'iPhone', language: 'en',
+      maxTouchPoints: 5, highEntropyData: { architecture: 'arm', bitness: '64' } }
+    const r = parseUA(UA.safari.ios, { ctx })
+    expect(r.arch).toBe('arm64')
+  })
+
+  it('ctx platform used as result.platform', () => {
+    const ctx = { userAgent: UA.chrome.windows, platform: 'Win32', language: 'en-US', maxTouchPoints: 0 }
+    const r = parseUA(UA.chrome.windows, { ctx })
+    expect(r.platform).toBe('Win32')
   })
 })
 


### PR DESCRIPTION
- 新增 getEnvContext()，采集 WebGL、Client Hints、字体探针等信号
- parseUA() 支持 ctx 选项，detectArch() 升级为四层检测链
- 新增 parseHeaders() 和 ACCEPT_CH，支持 SSR 场景精准检测
- isWebview() 新增 iOS WKWebView 识别
- HarmonyOS Next（5.0+）版本直接提取
- 新增 OpenHarmony 系统检测和 ArkWeb 引擎检测