### PR TITLE
feat: v1.2.0 新增七款主流 App 检测及六平台小程序支持

### DIFF
--- a/docs/en/guide/support-list.md
+++ b/docs/en/guide/support-list.md
@@ -23,14 +23,9 @@ Detection priority runs from lowest to highest. When multiple rules match the sa
 | Samsung Internet | `Samsung Internet` | 92 |
 | DuckDuckGo Browser | `DuckDuckGo` | 94 |
 | Puffin | `Puffin` | 96 |
-| Arora | `Arora` | 100 |
-| Lunascape | `Lunascape` | 110 |
-| QupZilla | `QupZilla` | 120 |
 | Coc Coc (Vietnam) | `Coc Coc` | 130 |
 | Amazon Kindle / Silk | `Kindle` | 140 |
-| Iceweasel | `Iceweasel` | 150 |
 | Konqueror | `Konqueror` | 160 |
-| Iceape | `Iceape` | 170 |
 | SeaMonkey | `SeaMonkey` | 180 |
 | Epiphany | `Epiphany` | 190 |
 | Maxthon | `Maxthon` | 200 |
@@ -72,10 +67,28 @@ Detection priority runs from lowest to highest. When multiple rules match the sa
 | iQiYi | `iQiYi` | 570 |
 | DingTalk | `DingTalk` | 580 |
 | TikTok (Douyin) | `Douyin` | 590 |
+| Bilibili | `Bilibili` | 592 |
+| Kuaishou (Kwai) | `Kuaishou` | 594 |
+| Xiaohongshu (RedNote) | `Xiaohongshu` | 596 |
+| Feishu / Lark | `Feishu` | 597 |
+| Toutiao (Today's Headlines) | `Toutiao` | 598 |
+| JD (Pingou) | `JD` | 599 |
+| Meituan | `Meituan` | 600 |
 
-::: tip WeChat Mini Program
-WeChat Mini Programs are detected separately via `isWechatMiniapp()` (relies on the `__wxjs_environment` global). The `browser` field returns `'Wechat Miniapp'`.
+::: tip Mini Program detection
+Each platform's mini programs are detected via runtime global variables. The `browser` field returns the corresponding Miniapp value:
+
+| Platform | Helper function | `browser` value | Runtime global |
+| :-- | :-- | :-- | :-- |
+| WeChat | `isWechatMiniapp()` | `'Wechat Miniapp'` | `__wxjs_environment` |
+| Alipay | `isAlipayMiniapp()` | `'Alipay Miniapp'` | `window.my.getSystemInfo` |
+| Baidu | `isBaiduMiniapp()` | `'Baidu Miniapp'` | `swan.getSystemInfo` |
+| Douyin | `isDouyinMiniapp()` | `'Douyin Miniapp'` | `tt.getSystemInfo` |
+| QQ | `isQQMiniapp()` | `'QQ Miniapp'` | `qq.getSystemInfo` |
+| Kuaishou | `isKuaishouMiniapp()` | `'Kuaishou Miniapp'` | `ks.getSystemInfo` |
 :::
+
+
 
 ---
 

--- a/docs/guide/support-list.md
+++ b/docs/guide/support-list.md
@@ -23,14 +23,9 @@
 | Samsung Internet | `Samsung Internet` | 92 |
 | DuckDuckGo 浏览器 | `DuckDuckGo` | 94 |
 | Puffin | `Puffin` | 96 |
-| Arora | `Arora` | 100 |
-| Lunascape | `Lunascape` | 110 |
-| QupZilla | `QupZilla` | 120 |
 | Coc Coc（越南） | `Coc Coc` | 130 |
 | Amazon Kindle / Silk | `Kindle` | 140 |
-| Iceweasel | `Iceweasel` | 150 |
 | Konqueror | `Konqueror` | 160 |
-| Iceape | `Iceape` | 170 |
 | SeaMonkey | `SeaMonkey` | 180 |
 | Epiphany | `Epiphany` | 190 |
 | 傲游浏览器 | `Maxthon` | 200 |
@@ -72,10 +67,28 @@
 | 爱奇艺 | `iQiYi` | 570 |
 | 钉钉 | `DingTalk` | 580 |
 | 抖音 | `Douyin` | 590 |
+| 哔哩哔哩 | `Bilibili` | 592 |
+| 快手 | `Kuaishou` | 594 |
+| 小红书 | `Xiaohongshu` | 596 |
+| 飞书 / Lark | `Feishu` | 597 |
+| 今日头条 | `Toutiao` | 598 |
+| 京东（拼购） | `JD` | 599 |
+| 美团 | `Meituan` | 600 |
 
-::: tip 微信小程序
-微信小程序通过 `isWechatMiniapp()` 单独检测（依赖 `__wxjs_environment` 全局变量），`browser` 字段返回 `'Wechat Miniapp'`。
+::: tip 小程序检测
+各平台小程序通过运行时全局变量检测，`browser` 字段返回对应 Miniapp 值：
+
+| 平台 | 辅助函数 | `browser` 返回值 | 全局变量 |
+| :-- | :-- | :-- | :-- |
+| 微信 | `isWechatMiniapp()` | `'Wechat Miniapp'` | `__wxjs_environment` |
+| 支付宝 | `isAlipayMiniapp()` | `'Alipay Miniapp'` | `window.my.getSystemInfo` |
+| 百度 | `isBaiduMiniapp()` | `'Baidu Miniapp'` | `swan.getSystemInfo` |
+| 抖音 | `isDouyinMiniapp()` | `'Douyin Miniapp'` | `tt.getSystemInfo` |
+| QQ | `isQQMiniapp()` | `'QQ Miniapp'` | `qq.getSystemInfo` |
+| 快手 | `isKuaishouMiniapp()` | `'Kuaishou Miniapp'` | `ks.getSystemInfo` |
 :::
+
+
 
 ---
 

--- a/src/constants/browsers.ts
+++ b/src/constants/browsers.ts
@@ -33,14 +33,9 @@ export const BROWSER_DEFS: readonly BrowserDef[] = [
   { name: 'Samsung Internet', priority: 92,  detect: /SamsungBrowser/,      versionPattern: /SamsungBrowser\/([\d.]+)/ },
   { name: 'DuckDuckGo',       priority: 94,  detect: /DuckDuckGo\//,        versionPattern: /DuckDuckGo\/([\d.]+)/ },
   { name: 'Puffin',           priority: 96,  detect: /Puffin\//,            versionPattern: /Puffin\/([\d.]+)/ },
-  { name: 'Arora',            priority: 100, detect: /Arora/,               versionPattern: /Arora\/([\d.]+)/ },
-  { name: 'Lunascape',     priority: 110, detect: /Lunascape/,           versionPattern: /Lunascape[\s]([\d.]+)/ },
-  { name: 'QupZilla',      priority: 120, detect: /QupZilla/,            versionPattern: /QupZilla[\s]([\d.]+)/ },
   { name: 'Coc Coc',       priority: 130, detect: /coc_coc_browser/,     versionPattern: /coc_coc_browser\/([\d.]+)/ },
   { name: 'Kindle',        priority: 140, detect: /(Kindle|Silk\/)/,     versionPattern: /Version\/([\d.]+)/ },
-  { name: 'Iceweasel',     priority: 150, detect: /Iceweasel/,           versionPattern: /Iceweasel\/([\d.]+)/ },
   { name: 'Konqueror',     priority: 160, detect: /Konqueror/,           versionPattern: /Konqueror\/([\d.]+)/ },
-  { name: 'Iceape',        priority: 170, detect: /Iceape/,              versionPattern: /Iceape\/([\d.]+)/ },
   { name: 'SeaMonkey',     priority: 180, detect: /SeaMonkey/,           versionPattern: /SeaMonkey\/([\d.]+)/ },
   { name: 'Epiphany',      priority: 190, detect: /Epiphany/,            versionPattern: /Epiphany\/([\d.]+)/ },
   { name: 'Maxthon',       priority: 200, detect: /Maxthon/,             versionPattern: /Maxthon\/([\d.]+)/ },
@@ -82,5 +77,12 @@ export const BROWSER_DEFS: readonly BrowserDef[] = [
   { name: 'Suning',        priority: 560, detect: /SNEBUY-APP/,          versionPattern: /SNEBUY-APP([\d.]+)/ },
   { name: 'iQiYi',         priority: 570, detect: /IqiyiApp/,            versionPattern: /IqiyiVersion\/([\d.]+)/ },
   { name: 'DingTalk',      priority: 580, detect: /DingTalk/,            versionPattern: /DingTalk\/([\d.]+)/ },
-  { name: 'Douyin',        priority: 590, detect: /aweme/,               versionPattern: /app_version\/([\d.]+)/ }
+  { name: 'Douyin',        priority: 590, detect: /aweme/,               versionPattern: /app_version\/([\d.]+)/ },
+  { name: 'Bilibili',      priority: 592, detect: /BiliBili\//,           versionPattern: /BiliBili\/([\d.]+)/ },
+  { name: 'Kuaishou',      priority: 594, detect: /Kwai\//,               versionPattern: /Kwai\/([\d.]+)/ },
+  { name: 'Xiaohongshu',   priority: 596, detect: /Xiaohongshu\//,        versionPattern: /Xiaohongshu\/([\d.]+)/ },
+  { name: 'Feishu',        priority: 597, detect: /(Lark|Feishu)\//,      versionPattern: [/Lark\/([\d.]+)/, /Feishu\/([\d.]+)/] },
+  { name: 'Toutiao',       priority: 598, detect: /NewsArticle\//,        versionPattern: /NewsArticle\/([\d.]+)/ },
+  { name: 'JD',            priority: 599, detect: /jdpingou\//,           versionPattern: /jdpingou\/([\d.]+)/ },
+  { name: 'Meituan',       priority: 600, detect: /MeituanHybrid\//,      versionPattern: /MeituanHybrid\/([\d.]+)/ }
 ] as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,52 @@ export const isWechatMiniapp = (): boolean => {
   }
 }
 
+/** Check whether the current context is an Alipay mini-program. */
+export const isAlipayMiniapp = (): boolean => {
+  try {
+    return typeof window !== 'undefined' &&
+      typeof (window as unknown as { my?: { getSystemInfo?: unknown } }).my?.getSystemInfo === 'function'
+  } catch {
+    return false
+  }
+}
+
+/** Check whether the current context is a Baidu Smart mini-program. */
+export const isBaiduMiniapp = (): boolean => {
+  try {
+    return typeof swan !== 'undefined' && typeof swan?.getSystemInfo === 'function'
+  } catch {
+    return false
+  }
+}
+
+/** Check whether the current context is a Douyin mini-program. */
+export const isDouyinMiniapp = (): boolean => {
+  try {
+    return typeof tt !== 'undefined' && typeof tt?.getSystemInfo === 'function'
+  } catch {
+    return false
+  }
+}
+
+/** Check whether the current context is a QQ mini-program. */
+export const isQQMiniapp = (): boolean => {
+  try {
+    return typeof qq !== 'undefined' && typeof qq?.getSystemInfo === 'function'
+  } catch {
+    return false
+  }
+}
+
+/** Check whether the current context is a Kuaishou mini-program. */
+export const isKuaishouMiniapp = (): boolean => {
+  try {
+    return typeof ks !== 'undefined' && typeof ks?.getSystemInfo === 'function'
+  } catch {
+    return false
+  }
+}
+
 // ── Default export — maintains v0.x call signature ──────────────────────────
 
 /**
@@ -42,6 +88,11 @@ function uaBrowser(ua?: string): EnvOption {
 
 uaBrowser.isWebview = isWebview
 uaBrowser.isWechatMiniapp = isWechatMiniapp
+uaBrowser.isAlipayMiniapp = isAlipayMiniapp
+uaBrowser.isBaiduMiniapp = isBaiduMiniapp
+uaBrowser.isDouyinMiniapp = isDouyinMiniapp
+uaBrowser.isQQMiniapp = isQQMiniapp
+uaBrowser.isKuaishouMiniapp = isKuaishouMiniapp
 uaBrowser.getLanguage = (): string => getLanguage(getNavContext())
 uaBrowser.VERSION = VERSION
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -130,6 +130,62 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
     }
   }
 
+  // Alipay Miniapp — my is a reserved word; accessed via window.my
+  if (browser === 'Alipay') {
+    try {
+      if (typeof window !== 'undefined' &&
+          typeof (window as unknown as { my?: { getSystemInfo?: unknown } }).my?.getSystemInfo === 'function') {
+        browser = 'Alipay Miniapp'
+      }
+    } catch {
+      // not in Alipay miniapp context
+    }
+  }
+
+  // Baidu Smart Miniapp (swan)
+  if (browser === 'Baidu') {
+    try {
+      if (typeof swan !== 'undefined' && typeof swan?.getSystemInfo === 'function') {
+        browser = 'Baidu Miniapp'
+      }
+    } catch {
+      // not in Baidu miniapp context
+    }
+  }
+
+  // Douyin Miniapp (tt)
+  if (browser === 'Douyin') {
+    try {
+      if (typeof tt !== 'undefined' && typeof tt?.getSystemInfo === 'function') {
+        browser = 'Douyin Miniapp'
+      }
+    } catch {
+      // not in Douyin miniapp context
+    }
+  }
+
+  // QQ Miniapp (qq)
+  if (browser === 'QQ') {
+    try {
+      if (typeof qq !== 'undefined' && typeof qq?.getSystemInfo === 'function') {
+        browser = 'QQ Miniapp'
+      }
+    } catch {
+      // not in QQ miniapp context
+    }
+  }
+
+  // Kuaishou Miniapp (ks)
+  if (browser === 'Kuaishou') {
+    try {
+      if (typeof ks !== 'undefined' && typeof ks?.getSystemInfo === 'function') {
+        browser = 'Kuaishou Miniapp'
+      }
+    } catch {
+      // not in Kuaishou miniapp context
+    }
+  }
+
   // iOS 26+: Apple freezes "CPU iPhone OS" at the last iOS 18 value for web compatibility.
   // The Version/ token reliably reflects the real Safari/iOS version.
   // When Version/ major > CPU iPhone OS major, use Version/ as the real osVersion.

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,14 +24,9 @@ export type BrowserName =
   | 'Samsung Internet'
   | 'DuckDuckGo'
   | 'Puffin'
-  | 'Arora'
-  | 'Lunascape'
-  | 'QupZilla'
   | 'Coc Coc'
   | 'Kindle'
-  | 'Iceweasel'
   | 'Konqueror'
-  | 'Iceape'
   | 'SeaMonkey'
   | 'Epiphany'
   | '360'
@@ -64,6 +59,18 @@ export type BrowserName =
   | 'iQiYi'
   | 'DingTalk'
   | 'Douyin'
+  | 'Bilibili'
+  | 'Kuaishou'
+  | 'Xiaohongshu'
+  | 'Feishu'
+  | 'Toutiao'
+  | 'JD'
+  | 'Meituan'
+  | 'Alipay Miniapp'
+  | 'Baidu Miniapp'
+  | 'Douyin Miniapp'
+  | 'QQ Miniapp'
+  | 'Kuaishou Miniapp'
   | 'unknown'
 
 export type OsName =
@@ -141,6 +148,15 @@ declare global {
   const __wxjs_environment: string
 
   // eslint-disable-next-line no-var
+  var swan: { getSystemInfo?: unknown } | undefined
+  // eslint-disable-next-line no-var
+  var tt: { getSystemInfo?: unknown } | undefined
+  // eslint-disable-next-line no-var
+  var qq: { getSystemInfo?: unknown } | undefined
+  // eslint-disable-next-line no-var
+  var ks: { getSystemInfo?: unknown } | undefined
+
+  // eslint-disable-next-line no-var
   var chrome: {
     adblock2345?: unknown
     common2345?: unknown
@@ -151,6 +167,10 @@ declare global {
 
   // eslint-disable-next-line no-var
   var u2f: unknown
+
+  interface Window {
+    my?: { getSystemInfo?: unknown }
+  }
 
   interface Navigator {
     browserLanguage?: string

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -167,6 +167,48 @@ describe('detectBrowser', () => {
       expect(r.browser).toBe('Douyin')
       expect(r.version).toBe('20.6.0')
     })
+
+    it('detects Bilibili', () => {
+      const r = detectBrowser(UA.bilibili.mobile)
+      expect(r.browser).toBe('Bilibili')
+      expect(r.version).toBe('6.24.0')
+    })
+
+    it('detects Kuaishou', () => {
+      const r = detectBrowser(UA.kuaishou.mobile)
+      expect(r.browser).toBe('Kuaishou')
+      expect(r.version).toBe('10.2.40.5370')
+    })
+
+    it('detects Xiaohongshu', () => {
+      const r = detectBrowser(UA.xiaohongshu.mobile)
+      expect(r.browser).toBe('Xiaohongshu')
+      expect(r.version).toBe('7.51.1')
+    })
+
+    it('detects Feishu (Lark token)', () => {
+      const r = detectBrowser(UA.feishu.mobile)
+      expect(r.browser).toBe('Feishu')
+      expect(r.version).toBe('6.8.9')
+    })
+
+    it('detects Toutiao', () => {
+      const r = detectBrowser(UA.toutiao.mobile)
+      expect(r.browser).toBe('Toutiao')
+      expect(r.version).toBe('8.7.5')
+    })
+
+    it('detects JD', () => {
+      const r = detectBrowser(UA.jd.mobile)
+      expect(r.browser).toBe('JD')
+      expect(r.version).toBe('3.5.0')
+    })
+
+    it('detects Meituan', () => {
+      const r = detectBrowser(UA.meituan.mobile)
+      expect(r.browser).toBe('Meituan')
+      expect(r.version).toBe('1.0')
+    })
   })
 
   describe('international browsers', () => {

--- a/test/compat.test.ts
+++ b/test/compat.test.ts
@@ -3,6 +3,11 @@ import uaBrowser, {
   parseUA,
   isWebview,
   isWechatMiniapp,
+  isAlipayMiniapp,
+  isBaiduMiniapp,
+  isDouyinMiniapp,
+  isQQMiniapp,
+  isKuaishouMiniapp,
   getLanguage,
   getNavContext,
   getWindowsVersion,
@@ -119,4 +124,16 @@ describe('API surface', () => {
     const crios = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0.0.0 Mobile/15E148 Safari/604.1'
     expect(isWebview(crios)).toBe(false)
   })
+
+  it('isAlipayMiniapp is a function', () => { expect(typeof isAlipayMiniapp).toBe('function') })
+  it('isBaiduMiniapp is a function', () => { expect(typeof isBaiduMiniapp).toBe('function') })
+  it('isDouyinMiniapp is a function', () => { expect(typeof isDouyinMiniapp).toBe('function') })
+  it('isQQMiniapp is a function', () => { expect(typeof isQQMiniapp).toBe('function') })
+  it('isKuaishouMiniapp is a function', () => { expect(typeof isKuaishouMiniapp).toBe('function') })
+
+  it('uaBrowser.isAlipayMiniapp is a function', () => { expect(typeof uaBrowser.isAlipayMiniapp).toBe('function') })
+  it('uaBrowser.isBaiduMiniapp is a function', () => { expect(typeof uaBrowser.isBaiduMiniapp).toBe('function') })
+  it('uaBrowser.isDouyinMiniapp is a function', () => { expect(typeof uaBrowser.isDouyinMiniapp).toBe('function') })
+  it('uaBrowser.isQQMiniapp is a function', () => { expect(typeof uaBrowser.isQQMiniapp).toBe('function') })
+  it('uaBrowser.isKuaishouMiniapp is a function', () => { expect(typeof uaBrowser.isKuaishouMiniapp).toBe('function') })
 })

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -96,6 +96,28 @@ export const UA = {
   openHarmony: {
     standard: 'Mozilla/5.0 (Linux; OpenHarmony 4.1; HONOR X8b Build/HONORX8b) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36',
   },
+  // New App WebViews
+  bilibili: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 BiliBili/6.24.0 os/android model/SM-G991B mobi_app/android'
+  },
+  kuaishou: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 Kwai/10.2.40.5370'
+  },
+  xiaohongshu: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 Xiaohongshu/7.51.1'
+  },
+  feishu: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 Lark/6.8.9 RangersAppID/1305903'
+  },
+  toutiao: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 NewsArticle/8.7.5'
+  },
+  jd: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 jdpingou/3.5.0'
+  },
+  meituan: {
+    mobile: 'Mozilla/5.0 (Linux; Android 12; SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36 MeituanHybrid/1.0'
+  },
   // Empty / edge cases
   empty: '',
   node: 'node-fetch/1.0 (+https://github.com/node-fetch/node-fetch)'

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -194,6 +194,50 @@ describe('parseUA — new fields (arch, isBot, isHeadless)', () => {
   })
 })
 
+describe('parseUA — miniapp runtime detection', () => {
+  it('Wechat UA + __wxjs_environment → Wechat Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).__wxjs_environment = 'miniprogram'
+    const r = parseUA(UA.wechat.mobile)
+    expect(r.browser).toBe('Wechat Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).__wxjs_environment
+  })
+
+  it('Alipay UA + window.my.getSystemInfo → Alipay Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).window = { my: { getSystemInfo: () => {} } }
+    const r = parseUA(UA.alipay.mobile)
+    expect(r.browser).toBe('Alipay Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).window
+  })
+
+  it('Baidu UA + swan.getSystemInfo → Baidu Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).swan = { getSystemInfo: () => {} }
+    const r = parseUA(UA.baidu.mobile)
+    expect(r.browser).toBe('Baidu Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).swan
+  })
+
+  it('Douyin UA + tt.getSystemInfo → Douyin Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).tt = { getSystemInfo: () => {} }
+    const r = parseUA(UA.douyin.mobile)
+    expect(r.browser).toBe('Douyin Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).tt
+  })
+
+  it('QQ UA + qq.getSystemInfo → QQ Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).qq = { getSystemInfo: () => {} }
+    const r = parseUA(UA.qq.qq)
+    expect(r.browser).toBe('QQ Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).qq
+  })
+
+  it('Kuaishou UA + ks.getSystemInfo → Kuaishou Miniapp', () => {
+    ;(globalThis as unknown as Record<string, unknown>).ks = { getSystemInfo: () => {} }
+    const r = parseUA(UA.kuaishou.mobile)
+    expect(r.browser).toBe('Kuaishou Miniapp')
+    delete (globalThis as unknown as Record<string, unknown>).ks
+  })
+})
+
 describe('parseUA — edge cases', () => {
   it('empty UA → all unknowns', () => {
     const r = parseUA('')


### PR DESCRIPTION
## 变更内容

### 清理
- 移除 5 个已停更浏览器：Arora、Lunascape、QupZilla、Iceweasel、Iceape

### 新增 App 内嵌 Webview 检测
| App | `BrowserName` | 优先级 |
| :-- | :-- | :--: |
| 哔哩哔哩 | `Bilibili` | 592 |
| 快手 | `Kuaishou` | 594 |
| 小红书 | `Xiaohongshu` | 596 |
| 飞书 / Lark | `Feishu` | 597 |
| 今日头条 | `Toutiao` | 598 |
| 京东（拼购） | `JD` | 599 |
| 美团 | `Meituan` | 600 |

### 新增小程序运行时检测
| 平台 | 辅助函数 | `browser` 返回值 |
| :-- | :-- | :-- |
| 支付宝 | `isAlipayMiniapp()` | `'Alipay Miniapp'` |
| 百度 | `isBaiduMiniapp()` | `'Baidu Miniapp'` |
| 抖音 | `isDouyinMiniapp()` | `'Douyin Miniapp'` |
| QQ | `isQQMiniapp()` | `'QQ Miniapp'` |
| 快手 | `isKuaishouMiniapp()` | `'Kuaishou Miniapp'` |

## 测试

218 个测试全部通过，无 TS 错误，构建正常。