### PR TITLE
docs: 补全 v1.1.0 / v1.2.0 新增 API 文档及使用示例

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,7 @@
 
 ### `uaBrowser(ua?)`
 
-解析 UA 并返回完整的环境信息对象。
+解析 UA 并返回完整的环境信息对象。在浏览器中自动注入 `navigator` 上下文。
 
 ```typescript
 import uaBrowser from 'ua-browser'
@@ -18,10 +18,17 @@ uaBrowser(ua?: string): EnvOption
 
 **返回值：** [`EnvOption`](/api/types#envoption)
 
+默认导出对象同时挂载了以下静态方法：
+
 ```typescript
 uaBrowser.isWebview(ua: string): boolean
 uaBrowser.isWechatMiniapp(): boolean
-uaBrowser.getLanguage(nav: NavContext): string
+uaBrowser.isAlipayMiniapp(): boolean
+uaBrowser.isBaiduMiniapp(): boolean
+uaBrowser.isDouyinMiniapp(): boolean
+uaBrowser.isQQMiniapp(): boolean
+uaBrowser.isKuaishouMiniapp(): boolean
+uaBrowser.getLanguage(): string
 uaBrowser.VERSION: string
 ```
 
@@ -31,7 +38,7 @@ uaBrowser.VERSION: string
 
 ### `parseUA(ua, options?)`
 
-纯函数版本，适合 SSR / Node.js 环境。
+纯函数版本，适合 SSR / Node.js 环境，无任何全局副作用。
 
 ```typescript
 import { parseUA } from 'ua-browser'
@@ -41,8 +48,9 @@ parseUA(ua: string, options?: ParseOptions): EnvOption
 
 ```typescript
 interface ParseOptions {
-  nav?: NavContext       // 注入浏览器环境上下文
+  nav?: NavContext              // 注入浏览器环境上下文（语言、平台等）
   windowsVersion?: string | null  // 预先获取的 Windows 版本
+  ctx?: EnvContext              // 多信号上下文，由 getEnvContext() 返回；传入后优先级高于 nav 和 windowsVersion
 }
 ```
 
@@ -50,7 +58,7 @@ interface ParseOptions {
 
 ### `isWebview(ua)`
 
-检测 UA 中是否包含 `; wv`（Android Webview 标识）。
+检测 UA 中是否包含 Android Webview 标识（`; wv`）或 iOS WKWebView 特征（无 `Version/` 且无 `Safari/`）。
 
 ```typescript
 isWebview(ua: string): boolean
@@ -60,10 +68,84 @@ isWebview(ua: string): boolean
 
 ### `isWechatMiniapp()`
 
-检测当前运行环境是否为微信小程序。
+检测当前运行环境是否为微信小程序（依赖 `__wxjs_environment` 全局变量）。
 
 ```typescript
 isWechatMiniapp(): boolean
+```
+
+---
+
+### 小程序检测函数
+
+各平台小程序通过运行时全局变量检测，仅在对应小程序环境中返回 `true`。
+
+| 函数 | 平台 | 检测依据 |
+| :-- | :-- | :-- |
+| `isAlipayMiniapp()` | 支付宝 | `window.my.getSystemInfo` |
+| `isBaiduMiniapp()` | 百度 | `swan.getSystemInfo` |
+| `isDouyinMiniapp()` | 抖音 | `tt.getSystemInfo` |
+| `isQQMiniapp()` | QQ | `qq.getSystemInfo` |
+| `isKuaishouMiniapp()` | 快手 | `ks.getSystemInfo` |
+
+```typescript
+import {
+  isAlipayMiniapp,
+  isBaiduMiniapp,
+  isDouyinMiniapp,
+  isQQMiniapp,
+  isKuaishouMiniapp,
+} from 'ua-browser'
+```
+
+当对应小程序全局 API 存在时，`parseUA()` 会自动将 `browser` 字段更新为对应的 Miniapp 值（如 `'Alipay Miniapp'`）。
+
+---
+
+### `getEnvContext()`
+
+一次性采集当前浏览器的所有环境信号（Client Hints、WebGL 渲染器、字体探针、媒体特性等），返回 `EnvContext` 对象。
+
+```typescript
+import { getEnvContext } from 'ua-browser'
+
+getEnvContext(): Promise<EnvContext>
+```
+
+采集到的信号用于提升架构检测精度（如区分 Apple Silicon 与 Intel Mac），以及提供更完整的运行时上下文。
+
+```typescript
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch)     // 'arm64'（基于 WebGL / Client Hints）
+console.log(result.language) // 'zh-CN'
+console.log(result.platform) // 'MacIntel'
+```
+
+> `getEnvContext()` 内所有 DOM API 均包裹在 `try/catch` 中，不会抛出异常。
+
+---
+
+### `parseHeaders(headers)`
+
+从 HTTP 请求头中解析 UA 及 Client Hints 信息，返回 `EnvOption`。适用于 SSR 精准检测场景。
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+parseHeaders(headers: Record<string, string | string[] | undefined>): EnvOption
+```
+
+在响应头中返回 `ACCEPT_CH`，告知支持的浏览器（Chrome / Edge 90+）在后续请求中携带 Client Hints：
+
+```typescript
+// Express / Koa / Next.js API Route
+res.setHeader('Accept-CH', ACCEPT_CH)
+
+// 后续请求携带 Client Hints 后，parseHeaders 可精确识别架构等信息
+const result = parseHeaders(req.headers)
+console.log(result.arch) // 'x86_64'（从 Sec-CH-UA-Arch 读取）
 ```
 
 ---
@@ -78,9 +160,7 @@ getWindowsVersion(nav: NavContext): Promise<string | null>
 
 需在调用 `parseUA` 前 `await`，然后作为 `windowsVersion` 选项传入。
 
-> **注意：** 依赖 `navigator.userAgentData`（Client Hints API），仅限支持该 API 的现代浏览器。Node.js 或不支持时返回 `null`。
-
-> **注意：** 依赖 `navigator.userAgentData`（Client Hints API），仅限支持该 API 的现代浏览器。Node.js 或不支持时返回 `null`。
+> 依赖 `navigator.userAgentData`（Client Hints API），仅限支持该 API 的现代浏览器（Chrome 90+）；Node.js 或不支持时返回 `null`。
 
 ---
 
@@ -94,12 +174,12 @@ detectBot(ua: string): { isBot: boolean; botName: BotName }
 
 ---
 
-### `detectArch(ua)`
+### `detectArch(ua, ctx?)`
 
-独立 CPU 架构检测器。
+独立 CPU 架构检测器，支持传入 `EnvContext` 以启用多信号检测。
 
 ```typescript
-detectArch(ua: string): ArchName
+detectArch(ua: string, ctx?: EnvContext): ArchName
 ```
 
 ---

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -4,7 +4,7 @@
 
 ### `uaBrowser(ua?)`
 
-Parse a UA string and return a full environment info object.
+Parse a UA string and return a full environment info object. Automatically injects `navigator` context in browser environments.
 
 ```typescript
 import uaBrowser from 'ua-browser'
@@ -18,10 +18,17 @@ uaBrowser(ua?: string): EnvOption
 
 **Returns:** [`EnvOption`](/en/api/types#envoption)
 
+The default export also exposes the following static methods:
+
 ```typescript
 uaBrowser.isWebview(ua: string): boolean
 uaBrowser.isWechatMiniapp(): boolean
-uaBrowser.getLanguage(nav: NavContext): string
+uaBrowser.isAlipayMiniapp(): boolean
+uaBrowser.isBaiduMiniapp(): boolean
+uaBrowser.isDouyinMiniapp(): boolean
+uaBrowser.isQQMiniapp(): boolean
+uaBrowser.isKuaishouMiniapp(): boolean
+uaBrowser.getLanguage(): string
 uaBrowser.VERSION: string
 ```
 
@@ -31,7 +38,7 @@ uaBrowser.VERSION: string
 
 ### `parseUA(ua, options?)`
 
-Pure function version, suitable for SSR / Node.js environments.
+Pure function version, suitable for SSR / Node.js environments, with no global side effects.
 
 ```typescript
 import { parseUA } from 'ua-browser'
@@ -41,8 +48,9 @@ parseUA(ua: string, options?: ParseOptions): EnvOption
 
 ```typescript
 interface ParseOptions {
-  nav?: NavContext       // inject browser environment context
+  nav?: NavContext              // inject browser environment context (language, platform, etc.)
   windowsVersion?: string | null  // pre-resolved Windows version
+  ctx?: EnvContext              // multi-signal context from getEnvContext(); takes priority over nav and windowsVersion
 }
 ```
 
@@ -50,7 +58,7 @@ interface ParseOptions {
 
 ### `isWebview(ua)`
 
-Detect whether the UA contains `; wv` (Android Webview marker).
+Detect whether the UA contains `; wv` (Android Webview marker) or iOS WKWebView characteristics (no `Version/` and no `Safari/`).
 
 ```typescript
 isWebview(ua: string): boolean
@@ -60,10 +68,84 @@ isWebview(ua: string): boolean
 
 ### `isWechatMiniapp()`
 
-Detect whether the current environment is a WeChat Mini Program.
+Detect whether the current environment is a WeChat Mini Program (relies on the `__wxjs_environment` global variable).
 
 ```typescript
 isWechatMiniapp(): boolean
+```
+
+---
+
+### Mini Program Detection Functions
+
+Each platform's Mini Program is detected via runtime global variables, returning `true` only in the corresponding Mini Program environment.
+
+| Function | Platform | Detection |
+| :-- | :-- | :-- |
+| `isAlipayMiniapp()` | Alipay | `window.my.getSystemInfo` |
+| `isBaiduMiniapp()` | Baidu | `swan.getSystemInfo` |
+| `isDouyinMiniapp()` | Douyin | `tt.getSystemInfo` |
+| `isQQMiniapp()` | QQ | `qq.getSystemInfo` |
+| `isKuaishouMiniapp()` | Kuaishou | `ks.getSystemInfo` |
+
+```typescript
+import {
+  isAlipayMiniapp,
+  isBaiduMiniapp,
+  isDouyinMiniapp,
+  isQQMiniapp,
+  isKuaishouMiniapp,
+} from 'ua-browser'
+```
+
+When the corresponding Mini Program global API is present, `parseUA()` automatically updates the `browser` field to the corresponding Miniapp value (e.g. `'Alipay Miniapp'`).
+
+---
+
+### `getEnvContext()`
+
+Collect all browser environment signals in one call (Client Hints, WebGL renderer, font probes, media features, etc.) and return an `EnvContext` object.
+
+```typescript
+import { getEnvContext } from 'ua-browser'
+
+getEnvContext(): Promise<EnvContext>
+```
+
+The collected signals improve architecture detection accuracy (e.g. distinguishing Apple Silicon from Intel Mac) and provide a richer runtime context.
+
+```typescript
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch)     // 'arm64' (from WebGL / Client Hints)
+console.log(result.language) // 'en-US'
+console.log(result.platform) // 'MacIntel'
+```
+
+> All DOM APIs inside `getEnvContext()` are wrapped in `try/catch` and will not throw.
+
+---
+
+### `parseHeaders(headers)`
+
+Parse UA and Client Hints from HTTP request headers and return an `EnvOption`. Suitable for precise SSR detection.
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+parseHeaders(headers: Record<string, string | string[] | undefined>): EnvOption
+```
+
+Return `ACCEPT_CH` in the response header to tell supporting browsers (Chrome / Edge 90+) to send Client Hints in subsequent requests:
+
+```typescript
+// Express / Koa / Next.js API Route
+res.setHeader('Accept-CH', ACCEPT_CH)
+
+// Once Client Hints are included, parseHeaders can accurately detect architecture and more
+const result = parseHeaders(req.headers)
+console.log(result.arch) // 'x86_64' (from Sec-CH-UA-Arch)
 ```
 
 ---
@@ -78,9 +160,7 @@ getWindowsVersion(nav: NavContext): Promise<string | null>
 
 `await` this before calling `parseUA`, then pass the result as the `windowsVersion` option.
 
-> **Note:** Requires `navigator.userAgentData` (Client Hints API). Browser-only — returns `null` in Node.js or when the API is unavailable.
-
-> **Note:** Requires `navigator.userAgentData` (Client Hints API). Browser-only — returns `null` in Node.js or when the API is unavailable.
+> Requires `navigator.userAgentData` (Client Hints API). Browser-only — returns `null` in Node.js or when the API is unavailable (Chrome 90+).
 
 ---
 
@@ -94,12 +174,12 @@ detectBot(ua: string): { isBot: boolean; botName: BotName }
 
 ---
 
-### `detectArch(ua)`
+### `detectArch(ua, ctx?)`
 
-Standalone CPU architecture detector.
+Standalone CPU architecture detector. Pass an `EnvContext` to enable multi-signal detection.
 
 ```typescript
-detectArch(ua: string): ArchName
+detectArch(ua: string, ctx?: EnvContext): ArchName
 ```
 
 ---

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -73,12 +73,19 @@ if (browser === 'IE') {
 
 ---
 
-## WeChat Environment Detection
+## Mini Program Detection
 
-Detect whether the app is running inside the WeChat browser or a Mini Program:
+Detect whether the app is running inside a Mini Program or an in-app browser across platforms:
 
 ```typescript
-import uaBrowser, { isWechatMiniapp } from 'ua-browser'
+import uaBrowser, {
+  isWechatMiniapp,
+  isAlipayMiniapp,
+  isBaiduMiniapp,
+  isDouyinMiniapp,
+  isQQMiniapp,
+  isKuaishouMiniapp,
+} from 'ua-browser'
 
 const { browser } = uaBrowser()
 
@@ -88,6 +95,21 @@ if (isWechatMiniapp()) {
 } else if (browser === 'Wechat') {
   // WeChat in-app browser
   initWechatSDK()
+} else if (isAlipayMiniapp()) {
+  // Alipay Mini Program
+  my.navigateTo({ url: '/pages/index/index' })
+} else if (isBaiduMiniapp()) {
+  // Baidu Smart Mini Program
+  swan.navigateTo({ url: '/pages/index/index' })
+} else if (isDouyinMiniapp()) {
+  // Douyin Mini Program
+  tt.navigateTo({ url: '/pages/index/index' })
+} else if (isQQMiniapp()) {
+  // QQ Mini Program
+  qq.navigateTo({ url: '/pages/index/index' })
+} else if (isKuaishouMiniapp()) {
+  // Kuaishou Mini Program
+  ks.navigateTo({ url: '/pages/index/index' })
 }
 ```
 
@@ -199,6 +221,47 @@ export function BrowserInfo() {
     <p>{info.browser} {info.version} on {info.os}</p>
   )
 }
+```
+
+---
+
+## High-Accuracy Architecture Detection (getEnvContext)
+
+Collect WebGL renderer, Client Hints, and other signals to distinguish Apple Silicon from Intel Mac:
+
+```typescript
+import { getEnvContext, parseUA } from 'ua-browser'
+
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch) // 'arm64' (Apple Silicon) or 'x86_64'
+```
+
+---
+
+## SSR Precise Detection (parseHeaders + Client Hints)
+
+Use HTTP Client Hints for accurate detection in Express / Next.js and similar server-side frameworks:
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+// First response: tell the browser to send Client Hints
+app.use((req, res, next) => {
+  res.setHeader('Accept-CH', ACCEPT_CH)
+  next()
+})
+
+// Subsequent requests: precise arch / OS detection
+app.get('/api/info', (req, res) => {
+  const result = parseHeaders(req.headers)
+  res.json({
+    browser: result.browser,
+    os:      result.os,
+    arch:    result.arch, // 'x86_64' (from Sec-CH-UA-Arch)
+  })
+})
 ```
 
 ---

--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -53,16 +53,24 @@ Import specific functions — Vite / Rollup / webpack 5+ will eliminate unused c
 
 ```typescript
 import {
-  parseUA,           // Pure function, ideal for SSR / Node.js
-  isWebview,         // Detect Android Webview
-  isWechatMiniapp,   // Detect WeChat Mini Program
-  getNavContext,     // Read current browser navigator context
-  getLanguage,       // Get browser language from NavContext
-  getWindowsVersion, // Async: accurately detect Windows 10 / 11
-  detectBot,         // Standalone bot detection
-  detectArch,        // Standalone CPU architecture detection
-  detectHeadless,    // Standalone headless browser detection
-  VERSION            // Current library version
+  parseUA,              // Pure function, ideal for SSR / Node.js
+  getNavContext,        // Read current browser navigator context
+  getWindowsVersion,    // Async: accurately distinguish Windows 10 / 11
+  getLanguage,          // Extract browser language from NavContext
+  getEnvContext,        // Collect all browser signals (Client Hints, WebGL, etc.)
+  parseHeaders,         // Parse UA and Client Hints from HTTP headers (SSR)
+  ACCEPT_CH,            // Response header constant to request Client Hints from browsers
+  isWebview,            // Detect Android Webview / iOS WKWebView
+  isWechatMiniapp,      // Detect WeChat Mini Program environment
+  isAlipayMiniapp,      // Detect Alipay Mini Program environment
+  isBaiduMiniapp,       // Detect Baidu Smart Mini Program environment
+  isDouyinMiniapp,      // Detect Douyin Mini Program environment
+  isQQMiniapp,          // Detect QQ Mini Program environment
+  isKuaishouMiniapp,    // Detect Kuaishou Mini Program environment
+  detectBot,            // Standalone bot detection
+  detectArch,           // Standalone CPU architecture detection
+  detectHeadless,       // Standalone headless browser detection
+  VERSION               // Current library version
 } from 'ua-browser'
 ```
 
@@ -93,6 +101,36 @@ const windowsVersion = await getWindowsVersion(nav)
 const result = parseUA(navigator.userAgent, { nav, windowsVersion })
 
 console.log(result.osVersion) // '11' or '10'
+```
+
+## High-Accuracy Architecture Detection (getEnvContext)
+
+`getEnvContext()` collects Client Hints, WebGL renderer, font probes, and other signals in one async call, enabling precise arch detection (e.g. Apple Silicon vs. Intel Mac):
+
+```typescript
+import { getEnvContext, parseUA } from 'ua-browser'
+
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch)     // 'arm64' (Apple Silicon) or 'x86_64'
+console.log(result.language) // 'en-US'
+```
+
+## SSR Client Hints (parseHeaders)
+
+Set the `ACCEPT_CH` response header to tell supporting browsers (Chrome / Edge 90+) to send Client Hints; then use `parseHeaders` to accurately parse them on subsequent requests:
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+// On the first response, set the Accept-CH header
+res.setHeader('Accept-CH', ACCEPT_CH)
+
+// On subsequent requests that include Client Hints
+const result = parseHeaders(req.headers)
+console.log(result.arch)    // 'x86_64' (from Sec-CH-UA-Arch)
+console.log(result.os)      // 'Windows'
 ```
 
 ## Browser (CDN)

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -73,21 +73,43 @@ if (browser === 'IE') {
 
 ---
 
-## 微信环境检测
+## 小程序环境检测
 
-判断是否在微信内置浏览器或小程序中运行：
+判断是否在各平台小程序或 App 内置浏览器中运行：
 
 ```typescript
-import uaBrowser, { isWechatMiniapp } from 'ua-browser'
+import uaBrowser, {
+  isWechatMiniapp,
+  isAlipayMiniapp,
+  isBaiduMiniapp,
+  isDouyinMiniapp,
+  isQQMiniapp,
+  isKuaishouMiniapp,
+} from 'ua-browser'
 
 const { browser } = uaBrowser()
 
 if (isWechatMiniapp()) {
-  // 微信小程序环境
+  // 微信小程序
   wx.navigateTo({ url: '/pages/index/index' })
 } else if (browser === 'Wechat') {
   // 微信内置浏览器
   initWechatSDK()
+} else if (isAlipayMiniapp()) {
+  // 支付宝小程序
+  my.navigateTo({ url: '/pages/index/index' })
+} else if (isBaiduMiniapp()) {
+  // 百度智能小程序
+  swan.navigateTo({ url: '/pages/index/index' })
+} else if (isDouyinMiniapp()) {
+  // 抖音小程序
+  tt.navigateTo({ url: '/pages/index/index' })
+} else if (isQQMiniapp()) {
+  // QQ 小程序
+  qq.navigateTo({ url: '/pages/index/index' })
+} else if (isKuaishouMiniapp()) {
+  // 快手小程序
+  ks.navigateTo({ url: '/pages/index/index' })
 }
 ```
 
@@ -199,6 +221,47 @@ export function BrowserInfo() {
     <p>{info.browser} {info.version} on {info.os}</p>
   )
 }
+```
+
+---
+
+## 高精度架构检测（getEnvContext）
+
+通过采集 WebGL 渲染器、Client Hints 等多维信号，区分 Apple Silicon 与 Intel Mac：
+
+```typescript
+import { getEnvContext, parseUA } from 'ua-browser'
+
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch) // 'arm64'（Apple Silicon）或 'x86_64'
+```
+
+---
+
+## SSR 精准检测（parseHeaders + Client Hints）
+
+在 Express / Next.js 等服务端框架中，利用 HTTP Client Hints 实现精准检测：
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+// 第一次响应：通知浏览器上报 Client Hints
+app.use((req, res, next) => {
+  res.setHeader('Accept-CH', ACCEPT_CH)
+  next()
+})
+
+// 后续请求：精准解析架构、OS 等信息
+app.get('/api/info', (req, res) => {
+  const result = parseHeaders(req.headers)
+  res.json({
+    browser: result.browser,
+    os:      result.os,
+    arch:    result.arch, // 'x86_64'（来自 Sec-CH-UA-Arch）
+  })
+})
 ```
 
 ---

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -53,16 +53,24 @@ console.log(info)
 
 ```typescript
 import {
-  parseUA,          // 纯函数版本，适合 SSR / Node.js
-  isWebview,        // 检测 Android Webview
-  isWechatMiniapp,  // 检测微信小程序
-  getNavContext,    // 读取当前浏览器 navigator 上下文
-  getLanguage,      // 获取浏览器语言
-  getWindowsVersion,// 异步获取精确 Windows 版本
-  detectBot,        // 爬虫检测
-  detectArch,       // CPU 架构检测
-  detectHeadless,   // 无头浏览器检测
-  VERSION           // 当前版本号
+  parseUA,              // 纯函数版本，适合 SSR / Node.js
+  getNavContext,        // 读取当前浏览器 navigator 上下文
+  getWindowsVersion,    // 异步精确区分 Windows 10 / 11
+  getLanguage,          // 从 NavContext 获取浏览器语言
+  getEnvContext,        // 采集所有浏览器环境信号（Client Hints、WebGL 等）
+  parseHeaders,         // 从 HTTP 请求头解析 UA 及 Client Hints（SSR）
+  ACCEPT_CH,            // 响应头常量，告知浏览器上报 Client Hints
+  isWebview,            // 检测 Android Webview / iOS WKWebView
+  isWechatMiniapp,      // 检测微信小程序
+  isAlipayMiniapp,      // 检测支付宝小程序
+  isBaiduMiniapp,       // 检测百度小程序
+  isDouyinMiniapp,      // 检测抖音小程序
+  isQQMiniapp,          // 检测 QQ 小程序
+  isKuaishouMiniapp,    // 检测快手小程序
+  detectBot,            // 独立爬虫检测
+  detectArch,           // 独立 CPU 架构检测
+  detectHeadless,       // 独立无头浏览器检测
+  VERSION               // 当前版本号
 } from 'ua-browser'
 ```
 
@@ -93,6 +101,36 @@ const windowsVersion = await getWindowsVersion(nav)
 const result = parseUA(navigator.userAgent, { nav, windowsVersion })
 
 console.log(result.osVersion) // '11' 或 '10'
+```
+
+## 高精度架构检测（getEnvContext）
+
+`getEnvContext()` 一次性采集 Client Hints、WebGL 渲染器、字体探针等多维信号，可区分 Apple Silicon 与 Intel Mac：
+
+```typescript
+import { getEnvContext, parseUA } from 'ua-browser'
+
+const ctx = await getEnvContext()
+const result = parseUA(navigator.userAgent, { ctx })
+
+console.log(result.arch)     // 'arm64'（Apple Silicon）或 'x86_64'
+console.log(result.language) // 'zh-CN'
+```
+
+## SSR Client Hints（parseHeaders）
+
+服务端通过返回 `ACCEPT_CH` 响应头，告知支持的浏览器（Chrome / Edge 90+）上报 Client Hints；后续请求中再用 `parseHeaders` 精准解析：
+
+```typescript
+import { parseHeaders, ACCEPT_CH } from 'ua-browser'
+
+// 第一次响应时写入 Accept-CH
+res.setHeader('Accept-CH', ACCEPT_CH)
+
+// 后续请求携带 Client Hints 后
+const result = parseHeaders(req.headers)
+console.log(result.arch)    // 'x86_64'（来自 Sec-CH-UA-Arch）
+console.log(result.os)      // 'Windows'
 ```
 
 ## 浏览器（CDN）用法


### PR DESCRIPTION
## 概述

补全 v1.1.0（多信号检测）和 v1.2.0（App + 小程序扩展）发布后缺失或过时的文档内容。

## 变更内容

**API 参考（中英文）**
- 新增 `getEnvContext()` 完整说明（v1.1.0，原文档缺失）
- 新增 `parseHeaders()` + `ACCEPT_CH` 说明（v1.1.0，原文档缺失）
- 新增 5 个小程序检测函数说明，附各平台检测依据表格（v1.2.0）
- 更新 `uaBrowser` 静态方法列表（补全 7 个小程序相关方法）
- 更新 `ParseOptions` 接口（补全 `ctx?: EnvContext` 字段）
- 更新 `detectArch` 签名（补全 `ctx?` 参数）
- 修复 `getWindowsVersion` 中重复的 Note 段落
- 修复 `isWebview` 描述（补充 iOS WKWebView 检测说明）

**快速开始（中英文）**
- 命名导出列表补全所有新增函数（共 19 个导出）
- 新增 `getEnvContext()` 用法节（多信号架构检测）
- 新增 `parseHeaders()` SSR Client Hints 用法节

**使用示例（中英文）**
- 微信小程序示例扩展为 6 平台完整示例（微信、支付宝、百度、抖音、QQ、快手）
- 新增 `getEnvContext()` 高精度架构检测示例
- 新增 `parseHeaders()` + `ACCEPT_CH` SSR 精准检测示例