### PR TITLE
fix: iOS 浏览器检测与 OS 版本修复，HarmonyOS 版本映射修正

### DIFF
--- a/src/constants/browsers.ts
+++ b/src/constants/browsers.ts
@@ -50,6 +50,7 @@ export const BROWSER_DEFS: readonly BrowserDef[] = [
     chromeLookup: { '86': '13.0', '78': '12.0', '69': '11.0', '63': '9.5',
                     '55': '9.0', '50': '8.7', '30': '7.5' } },
   { name: 'UC',            priority: 330, detect: /(UCBrowser|UBrowser|UCWEB)/, versionPattern: /UC?Browser\/([\d.]+)/ },
+  { name: 'UCMobile',     priority: 331, detect: /UCMobile\//,                versionPattern: /UCMobile\/([\d.]+)/ },
   { name: 'QQBrowser',     priority: 340, detect: /(MQQBrowser|QQBrowser)/,  versionPattern: [/MQQBrowser\/([\d.]+)/, /QQBrowser\/([\d.]+)/] },
   { name: 'QQ',            priority: 345, detect: /QQ\//,                versionPattern: /QQ\/([\d.]+)/ },
   { name: 'Baidu',         priority: 350, detect: /(Baidu|BIDUBrowser|baidubrowser|baiduboxapp|BaiduHD)/, versionPattern: [/BIDUBrowser[\s/]([\d.]+)/, /baiduboxapp\/([\d.]+)/] },

--- a/src/constants/os.ts
+++ b/src/constants/os.ts
@@ -42,7 +42,7 @@ export const OS_DEFS: readonly OsDef[] = [
   { name: 'Android',        priority: 20, detect: /(Android|Adr)/,                  versionPattern: /(?:Android|Adr) ([\d.]+)/ },
   { name: 'HarmonyOS',      priority: 30, detect: /HarmonyOS/,
     versionPattern: [/HarmonyOS[\s/]([\d.]+)/, /Android ([\d.]+)[;)]/],
-    versionLookup: { '10': '2', '11': '3', '12': '3', '13': '4', '14': '4' } },
+    versionLookup: { '10': '2', '11': '2', '12': '4', '13': '4', '14': '4', '15': '4', '16': '4' } },
   { name: 'OpenHarmony',    priority: 30, detect: /OpenHarmony/,                    versionPattern: /OpenHarmony[\s/]([\d.]+)/ },
   { name: 'KaiOS',          priority: 30, detect: /KAIOS/,                          versionPattern: /KAIOS\/([\d.]+)/ },
   { name: 'Windows',        priority: 10, detect: /Windows/,                        versionPattern: /Windows NT ([\d.]+)/,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -267,9 +267,18 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
   }
 
   // iOS 26+: Apple freezes "CPU iPhone OS" at the last iOS 18 value for web compatibility.
-  // The Version/ token reliably reflects the real Safari/iOS version.
-  if (os === 'iOS' && browser === 'Safari') {
-    const m = /Version\/([\d.]+)/.exec(ua)
+  // \bVersion/ (word boundary excludes ReleaseVersion/ etc.) carries the real iOS version.
+  // Apple provides this token to all third-party browsers, not just Safari.
+  if (os === 'iOS') {
+    const m = /\bVersion\/([\d.]+)/.exec(ua)
+    if (m && parseInt(m[1], 10) > parseInt(osVersion, 10)) {
+      osVersion = m[1]
+    }
+  }
+
+  // Baidu iOS freezes CPU iPhone OS but embeds real version in "(Baidu; P<n> <version>)".
+  if (os === 'iOS' && browser === 'Baidu') {
+    const m = /\(Baidu; P\d+ ([\d.]+)\)/.exec(ua)
     if (m && parseInt(m[1], 10) > parseInt(osVersion, 10)) {
       osVersion = m[1]
     }
@@ -338,6 +347,13 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
       })()
     : osVersionName
 
+  // Known independent browsers (non-app, non-unknown) are never webviews, even when
+  // their iOS UA lacks Version/ and Safari/ tokens. Android "; wv" is always reliable.
+  const rawIsWebview = isWebview(ua)
+  const finalIsWebview = /; wv/.test(ua)
+    ? true
+    : rawIsWebview && (browser === 'unknown' || browserType === 'app')
+
   return {
     browser,
     version,
@@ -352,7 +368,7 @@ export function parseUA(ua: string, options: ParseOptions = {}): EnvOption {
     vendor,
     model,
     arch,
-    isWebview: isWebview(ua),
+    isWebview: finalIsWebview,
     isHeadless,
     isBot,
     botName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type BrowserName =
   | '360EE'
   | '360SE'
   | 'UC'
+  | 'UCMobile'
   | 'QQBrowser'
   | 'QQ'
   | 'Baidu'

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -132,6 +132,12 @@ describe('detectBrowser', () => {
       expect(r.version).toBe('13.4.2.1306')
     })
 
+    it('detects UC浏览器 iOS (UCMobile token)', () => {
+      const r = detectBrowser(UA.uc.ios)
+      expect(r.browser).toBe('UCMobile')
+      expect(r.version).toBe('12.2.0.1260')
+    })
+
     it('detects Baidu box app', () => {
       const r = detectBrowser(UA.baidu.mobile)
       expect(r.browser).toBe('Baidu')

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -39,7 +39,9 @@ export const UA = {
   },
   opera: {
     modern: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 OPR/110.0.0.0',
-    legacy: 'Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.17'
+    legacy: 'Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.17',
+    // iOS 26+: CPU iPhone OS frozen at 18_7; Version/ carries real iOS version (Apple provides to all browsers)
+    ios26: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1 OPT/6.5.3'
   },
   // Chinese browsers
   wechat: {
@@ -55,10 +57,12 @@ export const UA = {
     ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 MQQBrowser/16.3.2 Mobile/15E148 Safari/604.1'
   },
   uc: {
-    mobile: 'Mozilla/5.0 (Linux; U; Android 9; zh-CN; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 UCBrowser/13.4.2.1306 Mobile Safari/537.36'
+    mobile: 'Mozilla/5.0 (Linux; U; Android 9; zh-CN; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 UCBrowser/13.4.2.1306 Mobile Safari/537.36',
+    ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X; en-US) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/23F77 UCMobile/12.2.0.1260 Mobile'
   },
   baidu: {
-    mobile: 'Mozilla/5.0 (Linux; Android 9; SM-G965F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Mobile Safari/537.36 baiduboxapp/12.19.0.10'
+    mobile: 'Mozilla/5.0 (Linux; Android 9; SM-G965F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Mobile Safari/537.36 baiduboxapp/12.19.0.10',
+    ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 SP-engine/3.59.0 main/1.0 baiduboxapp/15.64.0.10 (Baidu; P2 26.5) NABar/1.0 themeUA=Theme/default'
   },
   dingtalk: {
     mobile: 'Mozilla/5.0 (Linux; Android 11; SM-A515F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36 DingTalk/6.0.30'

--- a/test/fixtures/user-agents.ts
+++ b/test/fixtures/user-agents.ts
@@ -157,8 +157,10 @@ export const UA = {
   harmonyOs: {
     legacy: 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ANA-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 HuaweiBrowser/11.0.8.301 Mobile Safari/537.36',
     android11: 'Mozilla/5.0 (Linux; Android 11; NOH-AN00; HarmonyOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.48 Mobile Safari/537.36',
+    android12: 'Mozilla/5.0 (Linux; Android 12; HarmonyOS; DCO-AL00; HMSCore 6.14.0.322) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.196 HuaweiBrowser/15.0.9.300 Mobile Safari/537.36',
     android13: 'Mozilla/5.0 (Linux; Android 13; HarmonyOS; HUAWEI Mate60Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36',
     android14: 'Mozilla/5.0 (Linux; Android 14; HarmonyOS; HUAWEI Pura70) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+    android15: 'Mozilla/5.0 (Linux; Android 15; HarmonyOS; JAD-AL50) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36',
     next: 'Mozilla/5.0 (Linux; HarmonyOS 5.0.0; HUAWEI GT5 Pro Build/HUAWEIAGT5Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
     arkWeb: 'Mozilla/5.0 (Linux; HarmonyOS 5.0; Huawei ArkWeb/4.1.6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
   },

--- a/test/os.test.ts
+++ b/test/os.test.ts
@@ -85,10 +85,16 @@ describe('detectOs', () => {
     expect(r.osVersion).toBe('2')
   })
 
-  it('HarmonyOS with Android 11 base → HarmonyOS 3', () => {
+  it('HarmonyOS with Android 11 base → HarmonyOS 2', () => {
     const r = detectOs(UA.harmonyOs.android11)
     expect(r.os).toBe('HarmonyOS')
-    expect(r.osVersion).toBe('3')
+    expect(r.osVersion).toBe('2')
+  })
+
+  it('HarmonyOS with Android 12 base → HarmonyOS 4', () => {
+    const r = detectOs(UA.harmonyOs.android12)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('4')
   })
 
   it('HarmonyOS with Android 13 base → HarmonyOS 4', () => {
@@ -99,6 +105,12 @@ describe('detectOs', () => {
 
   it('HarmonyOS with Android 14 base → HarmonyOS 4', () => {
     const r = detectOs(UA.harmonyOs.android14)
+    expect(r.os).toBe('HarmonyOS')
+    expect(r.osVersion).toBe('4')
+  })
+
+  it('HarmonyOS with Android 15 base → HarmonyOS 4', () => {
+    const r = detectOs(UA.harmonyOs.android15)
     expect(r.os).toBe('HarmonyOS')
     expect(r.osVersion).toBe('4')
   })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -80,6 +80,15 @@ describe('parseUA — full pipeline', () => {
     expect(r.osVersion).toBe('14.3') // real macOS version from UA, not Safari version
   })
 
+  it('Opera on iOS 26 — CPU iPhone OS frozen at 18_7, Version/ reflects real version', () => {
+    const r = parseUA(UA.opera.ios26)
+    expect(r.browser).toBe('Opera')
+    expect(r.version).toBe('6.5.3')
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.5')
+    expect(r.isWebview).toBe(false)
+  })
+
   it('Chrome on iOS 26 — CriOS reports real OS version', () => {
     const r = parseUA(UA.chrome.crios26)
     expect(r.browser).toBe('Chrome')
@@ -206,6 +215,22 @@ describe('parseUA — webview detection', () => {
 
   it('no ; wv → isWebview: false', () => {
     expect(parseUA(UA.chrome.android).isWebview).toBe(false)
+  })
+
+  it('Baidu iOS (frozen CPU, (Baidu; P2 26.5) token) → isWebview: false, osVersion: 26.5', () => {
+    const r = parseUA(UA.baidu.ios)
+    expect(r.browser).toBe('Baidu')
+    expect(r.isWebview).toBe(false)
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.5')
+  })
+
+  it('UC浏览器 iOS (UCMobile, no Safari/) → isWebview: false, browser: UCMobile, osVersion: 26.5', () => {
+    const r = parseUA(UA.uc.ios)
+    expect(r.browser).toBe('UCMobile')
+    expect(r.isWebview).toBe(false)
+    expect(r.os).toBe('iOS')
+    expect(r.osVersion).toBe('26.5')
   })
 })
 


### PR DESCRIPTION
## 变更内容

### iOS 系统版本检测
- Opera 等第三方浏览器：`Version/` 覆盖逻辑扩展到所有 iOS 浏览器（不限 Safari）
- 百度 iOS：从 `(Baidu; P2 26.5)` token 提取真实系统版本

### isWebview 误判修复
- 夸克、UC浏览器、百度等缺少 `Safari/` 的 iOS 浏览器不再误判为 webview
- 覆盖条件：`browser !== 'unknown' && browserType !== 'app'`

### 浏览器识别
- UC浏览器 iOS 国内版（UCMobile token）拆分为独立 `'UCMobile'` 条目

### HarmonyOS 版本映射
| Android 版本 | 修复前 | 修复后 |
|---|---|---|
| 11 | 3 | 2 |
| 12 | 3 | 4 |
| 15 | 缺失 | 4 |
| 16 | 缺失 | 4 |

397 个测试全部通过