### PR TITLE
docs: 优化文档内容

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,12 +2,13 @@
 
 [![npm version](https://img.shields.io/npm/v/ua-browser?color=cb3837)](https://www.npmjs.com/package/ua-browser)
 [![npm downloads](https://img.shields.io/npm/dm/ua-browser)](https://www.npmjs.com/package/ua-browser)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/ua-browser)](https://bundlephobia.com/package/ua-browser)
 [![license](https://img.shields.io/npm/l/ua-browser)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-3178c6)](https://www.typescriptlang.org/)
 
-Detect browser, OS, device type, rendering engine, CPU architecture, bots, headless browsers, and Mini Programs from User Agent strings. Zero dependencies. Works in both browser and Node.js environments.
+Modern TypeScript-first User-Agent parser for browser and Node.js. Zero dependencies, tree-shakable. Goes beyond UA string parsing — hardware signals and Client Hints keep device, bot, and headless detection accurate even when UA strings lie.
 
-**[📖 Documentation](https://yangtianxia.github.io/ua-browser/)** · **[🎮 Playground](https://yangtianxia.github.io/ua-browser/playground)** · **[中文](./README.md)**
+**[📖 Documentation](https://yangtianxia.dev/ua-browser/)** · **[🎮 Playground](https://yangtianxia.dev/ua-browser/playground)** · **[中文](./README.md)**
 
 ## Features
 
@@ -234,7 +235,7 @@ import {
 
 ## Supported
 
-Over 70 browsers, 20 operating systems, and 40+ bot rules built in. See the **[full support list](https://yangtianxia.github.io/ua-browser/guide/support-list)**.
+Over 70 browsers, 20 operating systems, and 40+ bot rules built in. See the **[full support list](https://yangtianxia.dev/ua-browser/guide/support-list)**.
 
 Highlights:
 - **Browsers** — Chrome, Safari, Arc, Brave, Firefox, Edge, Samsung Internet, UC, WeChat, DingTalk, TikTok, Bilibili, Kuaishou, Xiaohongshu, Feishu, Zhihu, Pinduoduo, JD, NetEase Music, WPS Office; Instagram, Facebook, Twitter/X, TikTok, Snapchat, LinkedIn, Pinterest, Reddit, LINE, WhatsApp and more
@@ -262,7 +263,7 @@ Check the `isBot` and `botName` fields on the return value. Built-in rules cover
 
 **What is the bundle size?**
 
-Zero runtime dependencies. The bundle is tiny after gzip; tree-shaking named exports makes it smaller still.
+Zero runtime dependencies. Full bundle is 29.6KB minified, ~**9.5KB** gzip, ~**8.6KB** brotli. Tree-shaking named exports makes it smaller still.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [![npm version](https://img.shields.io/npm/v/ua-browser?color=cb3837)](https://www.npmjs.com/package/ua-browser)
 [![npm downloads](https://img.shields.io/npm/dm/ua-browser)](https://www.npmjs.com/package/ua-browser)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/ua-browser)](https://bundlephobia.com/package/ua-browser)
 [![license](https://img.shields.io/npm/l/ua-browser)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-3178c6)](https://www.typescriptlang.org/)
 
-通过 User Agent 检测浏览器、操作系统、设备类型、渲染内核、CPU 架构、爬虫、无头浏览器及小程序运行环境。零依赖，支持浏览器与 Node.js 双环境。
+TypeScript-first 的现代 User-Agent 解析库，零依赖，支持浏览器与 Node.js 双环境。不止解析 UA 字符串——额外引入硬件信号与 Client Hints，手机桌面模式、AI 爬虫、无头浏览器照样精准识别。
 
-**[📖 文档](https://yangtianxia.github.io/ua-browser/)** · **[🎮 Playground](https://yangtianxia.github.io/ua-browser/playground)** · **[English](./README.en.md)**
+**[📖 文档](https://yangtianxia.dev/ua-browser/)** · **[🎮 Playground](https://yangtianxia.dev/ua-browser/playground)** · **[English](./README.en.md)**
 
 ## 特性
 
@@ -232,7 +233,7 @@ import {
 
 ## 支持范围
 
-内置超过 70 种浏览器、20 种操作系统、40+ 种爬虫规则，详见 **[内置支持列表](https://yangtianxia.github.io/ua-browser/guide/support-list)**。
+内置超过 70 种浏览器、20 种操作系统、40+ 种爬虫规则，详见 **[内置支持列表](https://yangtianxia.dev/ua-browser/guide/support-list)**。
 
 部分覆盖：
 - **浏览器** — Chrome、Safari、Arc、Brave、Firefox、Edge、Samsung Internet、UC、微信、钉钉、抖音、哔哩哔哩、快手、小红书、飞书、知乎、拼多多、京东、网易云音乐、WPS Office；Instagram、Facebook、Twitter/X、TikTok、Snapchat、LinkedIn、Pinterest、Reddit、LINE、WhatsApp 等
@@ -260,7 +261,7 @@ import {
 
 **包体积有多大？**
 
-零运行时依赖，gzip 后极小；按需引入（named exports + tree-shaking）体积更小。
+零运行时依赖。完整打包 minify 后 29.6KB，gzip 约 **9.5KB**，brotli 约 **8.6KB**；按需引入（named exports + tree-shaking）体积更小。
 
 ## License
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
   sitemap: {
-    hostname: 'https://yangtianxia.github.io/ua-browser/',
+    hostname: 'https://yangtianxia.dev/ua-browser/',
   },
 
   head: [
@@ -29,7 +29,7 @@ export default defineConfig({
           { text: 'Playground', link: '/playground' },
           { text: '更新日志', link: '/changelog' },
           { text: '项目', items: [
-            { text: 'image-to-base64', link: 'https://yangtianxia.github.io/image-to-base64/' },
+            { text: 'image-to-base64', link: 'https://yangtianxia.dev/image-to-base64/' },
           ]},
         ],
 
@@ -69,7 +69,7 @@ export default defineConfig({
           { text: 'Playground', link: '/en/playground' },
           { text: 'Changelog', link: '/en/changelog' },
           { text: 'Projects', items: [
-            { text: 'image-to-base64', link: 'https://yangtianxia.github.io/image-to-base64/' },
+            { text: 'image-to-base64', link: 'https://yangtianxia.dev/image-to-base64/' },
           ]},
         ],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ua-browser",
   "version": "1.4.5",
-  "description": "uaBrowser - Browser, OS, engine and device detection from user agent strings. Supports Node.js. Zero dependencies.",
+  "description": "Modern TypeScript-first User-Agent parser for browser and Node.js. Zero dependencies, tree-shakable. Detects browser, OS, device type, engine, CPU architecture, headless browsers, AI bots, and WebView environments.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -46,19 +46,33 @@
     "url": "git+https://github.com/yangtianxia/ua-browser.git"
   },
   "keywords": [
-    "uaBrowser",
-    "userAgent",
-    "javascript",
-    "typescript",
+    "ua-browser",
+    "user-agent",
+    "user-agent-parser",
     "browser-detection",
-    "user-agent-parser"
+    "browser-parser",
+    "device-detection",
+    "os-detection",
+    "engine-detection",
+    "bot-detection",
+    "headless-browser",
+    "webview",
+    "client-hints",
+    "typescript",
+    "javascript",
+    "esm",
+    "nodejs",
+    "wechat",
+    "electron",
+    "ios",
+    "android"
   ],
   "author": "yangtianxia",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/yangtianxia/ua-browser/issues"
   },
-  "homepage": "https://github.com/yangtianxia/ua-browser#readme",
+  "homepage": "https://yangtianxia.dev/ua-browser",
   "devDependencies": {
     "@changesets/cli": "^2.29.4",
     "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
## 改动内容

- **package.json**：`description` 改为带定位的完整句；`keywords` 从 6 个扩充至 20 个（新增 `user-agent-parser`、`device-detection`、`bot-detection`、`headless-browser`、`webview`、`client-hints`、`wechat`、`electron` 等）
- **README / README.en.md**：第一屏描述句突出 TypeScript-first 与硬件信号差异化定位；新增 bundle size badge（bundlephobia 自动更新）；FAQ bundle size 从模糊描述改为真实数字（gzip 9.5KB / brotli 8.6KB）
- **docs/.vitepress/config.ts**：域名从 `yangtianxia.github.io` 更新为 `yangtianxia.dev`

## 说明

纯文档/元数据改动，无代码逻辑变更，无需版本号更新。  
`package.json` 的 `description` 和 `keywords` 将在下次 npm publish 时生效。